### PR TITLE
Move GitHub organization link to navbar

### DIFF
--- a/himvirasat-frontend/app/(public)/page.tsx
+++ b/himvirasat-frontend/app/(public)/page.tsx
@@ -101,16 +101,6 @@ export default function Home() {
             </Link>
           </Button>
 
-          <Button asChild className={actionButtonClass}>
-            <Link
-              href="https://github.com/HimVirasat"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <SiGithub className="h-16 w-16 scale-150" />
-              HimVirasat GitHub
-            </Link>
-          </Button>
 
           <Button asChild className={`${actionButtonClass}`}>
             <Link href="/datasets">

--- a/himvirasat-frontend/components/layout/Navbar.tsx
+++ b/himvirasat-frontend/components/layout/Navbar.tsx
@@ -60,6 +60,15 @@ export default function Navbar() {
           </span>
         </Link>
         <div className="hidden md:flex items-center gap-4">
+          <Link
+            href="https://github.com/HimVirasat"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="HimVirasat GitHub"
+            className="relative p-2 rounded-full text-foreground/70 hover:text-foreground hover:bg-foreground/5 transition-all duration-300"
+          >
+            <SiGithub className="h-5 w-5" />
+          </Link>
           <ul className="flex items-center gap-1">
             {navLinks.map((link) => {
               const isActive =
@@ -87,16 +96,8 @@ export default function Navbar() {
               );
             })}
           </ul>
-         
-          <Link
-            href="https://github.com/HimVirasat"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="HimVirasat GitHub"
-            className="relative p-2 rounded-full text-foreground/70 hover:text-foreground hover:bg-foreground/5 transition-all duration-300"
-          >
-            <SiGithub className="h-5 w-5" />
-          </Link>
+
+
 
 
         </div>
@@ -122,27 +123,27 @@ export default function Navbar() {
       >
         <div className="flex flex-col gap-4 text-center">
           {navLinks.map((link) => (
-            
-              <Link
-                key={link.name}
-                href={link.href}
-                onClick={() => setIsOpen(false)}
-                className="text-lg font-medium py-2 hover:text-emerald-600 transition-colors"
-              >
-                {link.name}
-              </Link>
-            
+
+            <Link
+              key={link.name}
+              href={link.href}
+              onClick={() => setIsOpen(false)}
+              className="text-lg font-medium py-2 hover:text-emerald-600 transition-colors"
+            >
+              {link.name}
+            </Link>
+
           ))}
           <Link
-              href="https://github.com/HimVirasat"
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => setIsOpen(false)}
-              aria-label="HimVirasat GitHub"
+            href="https://github.com/HimVirasat"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setIsOpen(false)}
+            aria-label="HimVirasat GitHub"
 
-              className="flex justify-center pt-2 text-foreground/70 hover:text-foreground transition-colors"
-            >
-              <SiGithub className="h-6 w-6" />
+            className="flex justify-center pt-2 text-foreground/70 hover:text-foreground transition-colors"
+          >
+            <SiGithub className="h-6 w-6" />
           </Link>
         </div>
       </div>

--- a/himvirasat-frontend/components/layout/Navbar.tsx
+++ b/himvirasat-frontend/components/layout/Navbar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { Menu, X } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
+import { SiGithub } from "@icons-pack/react-simple-icons";
 
 // TOGGLE THIS TO SWITCH MODES:
 // false = Shrinking Floating Pill
@@ -31,20 +32,17 @@ export default function Navbar() {
   ];
 
   const headerClasses = STRICT_STICKY
-    ? `fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
-        isScrolled
-          ? "bg-white/85 dark:bg-zinc-950/90 backdrop-blur-md border-b border-border/40 py-2"
-          : "bg-transparent py-4"
-      }`
-    : `fixed left-1/2 -translate-x-1/2 z-50 transition-all duration-300 ease-in-out ${
-        isScrolled ? "top-2 w-[88%] max-w-4xl" : "top-2 w-[92%] max-w-5xl"
-      }`;
+    ? `fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${isScrolled
+      ? "bg-white/85 dark:bg-zinc-950/90 backdrop-blur-md border-b border-border/40 py-2"
+      : "bg-transparent py-4"
+    }`
+    : `fixed left-1/2 -translate-x-1/2 z-50 transition-all duration-300 ease-in-out ${isScrolled ? "top-2 w-[88%] max-w-4xl" : "top-2 w-[92%] max-w-5xl"
+    }`;
 
   const navClasses = STRICT_STICKY
     ? "mx-auto max-w-7xl px-6 flex items-center justify-between"
-    : `glass bg-white/85 dark:bg-zinc-950/90 rounded-full backdrop-blur-md transition-all duration-300 flex items-center justify-between ${
-        isScrolled ? "px-6 py-2 shadow-xl" : "px-8 py-4 shadow-lg"
-      }`;
+    : `glass bg-white/85 dark:bg-zinc-950/90 rounded-full backdrop-blur-md transition-all duration-300 flex items-center justify-between ${isScrolled ? "px-6 py-2 shadow-xl" : "px-8 py-4 shadow-lg"
+    }`;
 
   return (
     <header className={headerClasses}>
@@ -61,35 +59,48 @@ export default function Navbar() {
             HimVirasat
           </span>
         </Link>
+        <div className="hidden md:flex items-center gap-4">
+          <ul className="flex items-center gap-1">
+            {navLinks.map((link) => {
+              const isActive =
+                link.href === "/"
+                  ? pathname === "/"
+                  : pathname.startsWith(link.href);
 
-        <ul className="hidden md:flex items-center gap-1">
-          {navLinks.map((link) => {
-            const isActive =
-              link.href === "/"
-                ? pathname === "/"
-                : pathname.startsWith(link.href);
-
-            return (
-              <Link
-                key={link.name}
-                href={link.href}
-                className={`
+              return (
+                <Link
+                  key={link.name}
+                  href={link.href}
+                  className={`
                   relative px-4 py-2 rounded-full text-sm font-medium transition-all duration-300
-                  ${
-                    isActive
+                  ${isActive
                       ? "text-emerald-700 dark:text-emerald-400 bg-emerald-500/10"
                       : "text-foreground/70 hover:text-foreground hover:bg-foreground/5"
-                  }
+                    }
                 `}
-              >
-                {link.name}
-                {isActive && (
-                  <span className="absolute bottom-1 left-1/2 -translate-x-1/2 w-1 h-1 bg-emerald-500 rounded-full animate-pulse" />
-                )}
-              </Link>
-            );
-          })}
-        </ul>
+                >
+                  {link.name}
+                  {isActive && (
+                    <span className="absolute bottom-1 left-1/2 -translate-x-1/2 w-1 h-1 bg-emerald-500 rounded-full animate-pulse" />
+                  )}
+                </Link>
+              );
+            })}
+          </ul>
+         
+          <Link
+            href="https://github.com/HimVirasat"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="HimVirasat GitHub"
+            className="relative p-2 rounded-full text-foreground/70 hover:text-foreground hover:bg-foreground/5 transition-all duration-300"
+          >
+            <SiGithub className="h-5 w-5" />
+          </Link>
+
+
+        </div>
+
 
         <button
           onClick={() => setIsOpen(!isOpen)}
@@ -111,15 +122,28 @@ export default function Navbar() {
       >
         <div className="flex flex-col gap-4 text-center">
           {navLinks.map((link) => (
-            <Link
-              key={link.name}
-              href={link.href}
-              onClick={() => setIsOpen(false)}
-              className="text-lg font-medium py-2 hover:text-emerald-600 transition-colors"
-            >
-              {link.name}
-            </Link>
+            
+              <Link
+                key={link.name}
+                href={link.href}
+                onClick={() => setIsOpen(false)}
+                className="text-lg font-medium py-2 hover:text-emerald-600 transition-colors"
+              >
+                {link.name}
+              </Link>
+            
           ))}
+          <Link
+              href="https://github.com/HimVirasat"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setIsOpen(false)}
+              aria-label="HimVirasat GitHub"
+
+              className="flex justify-center pt-2 text-foreground/70 hover:text-foreground transition-colors"
+            >
+              <SiGithub className="h-6 w-6" />
+          </Link>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Changes
- Moved the GitHub organization link from the homepage to the navigation bar.
- Displayed the link using the GitHub icon.
- Removed the GitHub button from the homepage.
- Added the GitHub icon to the mobile navigation for consistent access.

Fixes #30 