### PR TITLE
fix: use canonical search key for dictionary entry search button

### DIFF
--- a/himvirasat-frontend/components/vocabulary/VocabularyCard.tsx
+++ b/himvirasat-frontend/components/vocabulary/VocabularyCard.tsx
@@ -9,6 +9,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Copy, Search, MapPin, User } from "lucide-react";
+import { cleanText } from "@/lib/vocabulary/search-vocabulary";
 
 function escapeRegExp(s: string) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -111,7 +112,7 @@ export default memo(function VocabularyCard({
             <Button
               size="sm"
               variant="outline"
-              onClick={() => onSearch(entry.word_native)}
+              onClick={() => onSearch(cleanText(entry.word_native))}
             >
               <Search className="h-3.5 w-3.5 mr-1 shrink-0" />
               Search

--- a/himvirasat-frontend/lib/vocabulary/search-vocabulary.ts
+++ b/himvirasat-frontend/lib/vocabulary/search-vocabulary.ts
@@ -18,7 +18,7 @@ function getLevenshteinDistance(a: string, b: string): number {
   return matrix[b.length][a.length];
 }
 
-function cleanText(text: string): string {
+export function cleanText(text: string): string {
   return text
     .replace(/\s*\([^)]*\)/g, "") // Remove everything in brackets
     .trim()


### PR DESCRIPTION
## Description
Fixes a bug where clicking the "Search" button on a dictionary entry populated the search input with the formatted display label (e.g., `kune (कुणे)`) instead of the canonical searchable key (e.g., `kune`). Because the application's search implementation expects the canonical string, this previously resulted in zero matches.

## Changes Made
- **`himvirasat-frontend/lib/vocabulary/search-vocabulary.ts`**: Exported the existing `cleanText` function so it can be securely reused by other components to extract the canonical search key.
- **`himvirasat-frontend/components/vocabulary/VocabularyCard.tsx`**: Imported `cleanText` and updated the Search button's `onClick` handler to wrap the payload: `onSearch(cleanText(entry.word_native))`.

## Why this approach?
This fix resolves the issue at the lowest appropriate layer by reusing the codebase's existing canonical parsing mechanism. It avoids duplicating arbitrary string parsing (like `.split("(")[0]`) haphazardly inside the UI layer. This ensures the search input reliably receives only the base romanized word while the visual UI display (with Devanagari text) remains completely preserved.

## Validation
- ✅ Manually verified that opening an entry and pressing "Search" fills the input with only the canonical value (`kune`).
- ✅ Confirmed that clicking the button immediately triggers a successful search returning the same entry.
- ✅ Existing search functionality and formatting are unchanged.

Fixes : #40
