### PR TITLE
feat(ui): editorial design system and public site refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ coverage/
 !.env.example
 !**/.env.example
 .pnpm-debug.log*
+
+# The Vercel link lives at the repo root now: vercel.json does `cd ..`, so
+# the deployment root has to be the workspace root with the project's Root
+# Directory pointing at himvirasat-frontend.
+.vercel

--- a/himvirasat-frontend/app/(public)/about/page.tsx
+++ b/himvirasat-frontend/app/(public)/about/page.tsx
@@ -1,100 +1,113 @@
-import Image from "next/image";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
+
 import { TeamSection } from "@/components/about/team-section";
+import { InkBand } from "@/components/mistral/ink-band";
+import { RuledCell, RuledGrid } from "@/components/mistral/ruled-grid";
+import { SectionHeading } from "@/components/mistral/section-heading";
+import { Button } from "@/components/ui/button";
+import { site } from "@/lib/site";
+import { devToTankri } from "@/lib/transliteration/devToTankri";
+
+export const metadata = {
+  title: "About & Team",
+  description:
+    "From maintaining a digital archive to developing open source Pahadi learning tools, HimVirasat is building the infrastructure for Himachal's digital future.",
+};
+
+const commitments = [
+  {
+    title: "Collaborative engineering",
+    body: "Today we gather data through structured community forms. A dedicated contribution platform, built by the community for the community, is next.",
+  },
+  {
+    title: "Open learning",
+    body: "Free tools that help the next generation learn their mother tongue, blending traditional knowledge with modern language technology.",
+  },
+];
+
 export default function AboutPage() {
   return (
-    <div className="relative min-h-screen">
+    <div>
+      <header className="mx-auto w-full max-w-content px-6 py-20 md:py-28 lg:px-10">
+        <SectionHeading
+          as="h1"
+          align="left"
+          eyebrow="Our vision"
+          nativeEcho={devToTankri("दृष्टि")}
+          title="Bridging heritage and innovation."
+        />
+      </header>
+
+      <InkBand>
+        <div className="mx-auto w-full max-w-content px-6 py-20 md:py-28 lg:px-10">
+          <h2 className="text-display-md max-w-3xl text-balance">
+            Beyond just words.
+          </h2>
+          <p className="text-body-lg mt-6 max-w-3xl text-muted-foreground">
+            HimVirasat is not only a dictionary, it is a technical ecosystem.
+            From maintaining this digital archive to developing{" "}
+            <strong className="font-medium text-foreground">
+              open source Pahadi learning tools
+            </strong>
+            , we are building the infrastructure for Himachal&rsquo;s digital
+            future. The work scales from{" "}
+            <strong className="font-medium text-foreground">
+              specialised language models
+            </strong>{" "}
+            to live{" "}
+            <strong className="font-medium text-foreground">
+              dialect translators
+            </strong>
+            .
+          </p>
+        </div>
+      </InkBand>
+
+      <section className="mx-auto w-full max-w-content px-6 py-20 md:py-28 lg:px-10">
+        <RuledGrid cols={2}>
+          {commitments.map((item) => (
+            <RuledCell key={item.title} className="p-8 lg:p-10">
+              <h3 className="text-title">{item.title}</h3>
+              <p className="text-body-sm text-muted-foreground mt-3">
+                {item.body}
+              </p>
+            </RuledCell>
+          ))}
+        </RuledGrid>
+      </section>
+
+      <section className="border-border border-y">
+        <div className="mx-auto w-full max-w-content px-6 py-20 text-center md:py-24 lg:px-10">
+          <h2 className="text-display-md text-balance">
+            Become part of the movement.
+          </h2>
+          <p className="text-body-lg text-muted-foreground mx-auto mt-5 max-w-2xl">
+            Whether you are a native speaker, a linguist, or a developer, your
+            contribution matters.
+          </p>
+          <div className="mt-9 flex flex-wrap justify-center gap-3">
+            <Button asChild size="lg">
+              <Link href="/contribute">Contribute data</Link>
+            </Button>
+            <Button asChild size="lg" variant="secondary">
+              <a
+                href={site.links.discordHimvirasat}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Join Discord
+              </a>
+            </Button>
+          </div>
+        </div>
+      </section>
+
       <div
-        className="fixed inset-0 bg-cover bg-center -z-10"
-        style={{ backgroundImage: "url('/mountains1.png')" }}
-      />
-      <div className="fixed inset-0 bg-white/70 dark:bg-black/85 -z-10" />
-
-      <main className="max-w-5xl mx-auto px-6 py-24 sm:py-32">
-        <header className="space-y-4">
-          <span className="text-emerald-600 dark:text-emerald-400 font-bold tracking-widest uppercase text-xs">
-            Our Vision
-          </span>
-          <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-slate-900 dark:text-white leading-tight">
-            Bridging the gap between <br />
-            <span className="text-emerald-600 dark:text-emerald-400 italic">
-              Heritage and Innovation.
-            </span>
-          </h1>
-        </header>
-
-        <section className="mt-16 space-y-12">
-          <div className="rounded-3xl bg-white/40 dark:bg-white/5 border border-white/20 p-8 backdrop-blur-md">
-            <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
-              Beyond Just Words
-            </h2>
-            <p className="mt-4 text-slate-800 dark:text-zinc-300 leading-relaxed">
-              {`HimVirasat isn't just a dictionary; it's a technical ecosystem.`}{" "}
-              From maintaining this digital archive to developing
-              <strong> open-source Pahadi learning tools</strong>, we are
-              building the infrastructure for Himachal’s digital future. Our
-              vision scales from{" "}
-              <strong>specialized LLMs (Large Language Models)</strong> to
-              real-time <strong>dialect translators</strong>.
-            </p>
-          </div>
-
-          <div className="grid md:grid-cols-2 gap-8">
-            <div className="space-y-3">
-              <h3 className="text-xl font-semibold text-emerald-700 dark:text-emerald-400">
-                Collaborative Engineering
-              </h3>
-              <p className="text-slate-700 dark:text-zinc-400 text-sm leading-relaxed">
-                Currently, we use structured community forms to gather data.
-                Soon, we will launch a
-                <strong> dedicated contribution platform</strong> developed by
-                our community, for our community.
-              </p>
-            </div>
-            <div className="space-y-3">
-              <h3 className="text-xl font-semibold text-emerald-700 dark:text-emerald-400">
-                Open Learning
-              </h3>
-              <p className="text-slate-700 dark:text-zinc-400 text-sm leading-relaxed">
-                We are committed to creating free tools that help the next
-                generation learn their mother tongue, blending traditional
-                knowledge with modern AI.
-              </p>
-            </div>
-          </div>
-
-          <div className="rounded-3xl bg-emerald-600/10 border border-emerald-500/20 p-8 text-center">
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">
-              Become Part of the Movement
-            </h2>
-            <p className="mt-2 text-slate-700 dark:text-zinc-300">
-              Whether you are a native speaker, a linguist, or a developer—your
-              contribution matters.
-            </p>
-            <div className="mt-8 flex flex-col sm:flex-row justify-center gap-4">
-              <Button
-                asChild
-                className="rounded-full px-8 bg-emerald-600 hover:bg-emerald-700 text-white border-none"
-              >
-                <Link href="/contribute">Contribute Data</Link>
-              </Button>
-              <Button
-                asChild
-                variant="outline"
-                className="rounded-full px-8 border-slate-300 dark:border-white/20"
-              >
-                <Link href="https://discord.gg/PgJWcFXRTB" target="_blank">
-                  Join Discord
-                </Link>
-              </Button>
-            </div>
-          </div>
-        </section>
-        <section id="team">
-          <TeamSection />
-        </section>
-      </main>
+        id="team"
+        className="mx-auto w-full max-w-content scroll-mt-24 px-6 lg:px-10"
+      >
+        <TeamSection />
+      </div>
     </div>
   );
 }

--- a/himvirasat-frontend/app/(public)/contribute/page.tsx
+++ b/himvirasat-frontend/app/(public)/contribute/page.tsx
@@ -1,96 +1,145 @@
+import type { Metadata } from "next";
+
 import DialectCard from "@/components/dialects/DialectCard";
+import { Eyebrow } from "@/components/mistral/eyebrow";
+import { RuledGrid } from "@/components/mistral/ruled-grid";
+import { SectionHeading } from "@/components/mistral/section-heading";
+import { Reveal } from "@/components/motion/reveal";
+import { devToTankri } from "@/lib/transliteration/devToTankri";
+
+export const metadata: Metadata = {
+  title: "Contribute",
+  description:
+    "Contribute translation sentences in your Himachali dialect through simple forms.",
+};
+
+const dialects = [
+  {
+    id: "kangri",
+    name: "Kangri",
+    formUrl: "https://forms.gle/fgENxd2t5a62vuBSA",
+  },
+  {
+    id: "mandeali",
+    name: "Mandeali",
+    formUrl: "https://forms.gle/ApxgyyQGswns7uwM8",
+  },
+  {
+    id: "kullvi",
+    name: "Kullvi",
+    formUrl: "https://forms.gle/Gnecc3PWtYFz4v7w6",
+  },
+  {
+    id: "mahasuvi_western",
+    name: "Mahasuvi (Western)",
+    formUrl: "https://forms.gle/dgPsVoDyhW8hGG1n9",
+  },
+  {
+    id: "mahasuvi_eastern",
+    name: "Mahasuvi (Eastern)",
+    formUrl: "https://forms.gle/2aec4T8BYCGdv5vy9",
+  },
+  {
+    id: "kinnauri",
+    name: "Kinnauri",
+    formUrl: "https://forms.gle/ptALNWptVu7PFcN4A",
+  },
+];
+
+const steps = [
+  {
+    numeral: "𑛁",
+    title: "Pick your dialect",
+    line: "Choose your dialect from the forms below.",
+  },
+  {
+    numeral: "𑛂",
+    title: "Write everyday sentences",
+    line: "Write the words you use every day, with their Hindi translations, in the form.",
+  },
+  {
+    numeral: "𑛃",
+    title: "Reviewed and credited",
+    line: "Every contribution is tracked and verified, and contributors are recognised and credited.",
+  },
+];
 
 export default function ContributePage() {
-  const dialects = [
-    {
-      id: "kangri",
-      name: "Kangri",
-      formUrl: "https://forms.gle/fgENxd2t5a62vuBSA",
-    },
-    {
-      id: "mandeali",
-      name: "Mandeali",
-      formUrl: "https://forms.gle/ApxgyyQGswns7uwM8",
-    },
-    {
-      id: "kullvi",
-      name: "Kullvi",
-      formUrl: "https://forms.gle/Gnecc3PWtYFz4v7w6",
-    },
-    {
-      id: "mahasuvi_western",
-      name: "Mahasuvi (Western)",
-      formUrl: "https://forms.gle/dgPsVoDyhW8hGG1n9",
-    },
-    {
-      id: "mahasuvi_eastern",
-      name: "Mahasuvi (Eastern)",
-      formUrl: "https://forms.gle/2aec4T8BYCGdv5vy9",
-    },
-    {
-      id: "kinnauri",
-      name: "Kinnauri",
-      formUrl: "https://forms.gle/ptALNWptVu7PFcN4A",
-    },
-  ];
-
   return (
-    <div className="relative min-h-screen overflow-hidden">
-      <div
-        className="absolute inset-0 bg-cover bg-center"
-        style={{ backgroundImage: "url('/mountains1.png')" }}
+    <div className="mx-auto w-full max-w-content px-6 py-20 md:py-28 lg:px-10">
+      <SectionHeading
+        as="h1"
+        align="left"
+        eyebrow="Contribute"
+        nativeEcho={devToTankri("योगदान")}
+        title="Language and translation contributions"
+        description="Choose your dialect below and contribute parallel sentences to help build open Hindi to Himachali translation datasets for research, education, and language tools."
       />
 
-      <div className="absolute inset-0 bg-white/60 dark:bg-black/85" />
-
-      <main className="relative z-10 mx-auto max-w-4xl px-6 py-24 sm:px-12">
-        <section>
-          <h2 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
-            Language & Translation Contributions
+      <div className="mt-16 grid gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,20rem)]">
+        <div className="text-body text-muted-foreground max-w-prose space-y-5">
+          <h2 className="text-display-md text-foreground">
+            Your words matter
           </h2>
-          <p className="mt-4 max-w-3xl text-base leading-7 text-zinc-700 dark:text-zinc-300">
-            Choose your dialect below and contribute parallel sentences to help
-            build open Hindi ↔ Himachali translation datasets for research,
-            education, and language tools.
+          <p>
+            Every word you contribute helps keep Himachal&rsquo;s languages
+            alive in the digital world. Even a single word or sentence from your
+            dialect is valuable. It captures how people actually speak,
+            something no book or machine can recreate.
           </p>
-          <h3 className="mt-12 text-xl font-semibold text-zinc-900 dark:text-zinc-100">
-            🌱 Your Words Matter
-          </h3>
-          <p className="mt-4 max-w-3xl text-base leading-7 text-zinc-700 dark:text-zinc-300">
-            Every word you contribute helps keep Himachal’s languages alive in
-            the digital world. Even a single word or sentence from your dialect
-            is valuable. It captures how people actually speak, something no
-            book or machine can recreate.
-          </p>
-
-          <p className="mt-4 max-w-3xl text-base leading-7 text-zinc-700 dark:text-zinc-300">
+          <p>
             All contributions to HimVirasat are carefully tracked and verified,
-            ensuring that your effort is never lost or overlooked. As the
-            project grows, contributors will be recognized and credited across
-            our official platforms, including the HimVirasat website, our
-            official Discord server, and community posts on Reddit.
+            ensuring your effort is never lost or overlooked. As the project
+            grows, contributors will be recognised and credited across our
+            official platforms, including the HimVirasat website, our Discord
+            server, and community posts.
           </p>
-
-          <p className="mt-4 max-w-3xl text-base leading-7 text-zinc-700 dark:text-zinc-300">
-            You don’t need to be an expert. Just write the words you use every
-            day that’s how a language truly lives on.
+          <p>
+            You do not need to be an expert. Just write the words you use every
+            day. That is how a language truly lives on.
           </p>
+        </div>
 
-          <p className="mt-4 font-medium text-zinc-900 dark:text-zinc-100">
-            One word today can preserve a language tomorrow.
-          </p>
+        <blockquote className="border-pine-500 text-title text-foreground h-fit border-l-2 pl-6">
+          One word today can preserve a language tomorrow.
+        </blockquote>
+      </div>
 
-          <div className="mt-8 grid gap-6 sm:grid-cols-2">
-            {dialects.map((dialect) => (
-              <DialectCard
-                key={dialect.id}
-                name={dialect.name}
-                formUrl={dialect.formUrl}
-              />
-            ))}
-          </div>
-        </section>
-      </main>
+      <section aria-label="How contributing works" className="mt-20">
+        <Eyebrow className="mb-6">How it works</Eyebrow>
+        <RuledGrid cols={3} as="ol">
+          {steps.map((step) => (
+            <li key={step.title} className="ruled-cell p-8">
+              <span
+                aria-hidden
+                className="bg-pine-100 font-takri grid size-12 place-items-center text-2xl text-[#07070b]"
+              >
+                {step.numeral}
+              </span>
+              <h3 className="text-title mt-5">{step.title}</h3>
+              <p className="text-body-sm text-muted-foreground mt-2">
+                {step.line}
+              </p>
+            </li>
+          ))}
+        </RuledGrid>
+      </section>
+
+      <section aria-label="Dialect forms" className="mt-20">
+        <Eyebrow className="mb-6">Dialects collecting now</Eyebrow>
+        <RuledGrid cols="2-3" as="ul">
+          {dialects.map((dialect, index) => (
+            <Reveal
+              as="li"
+              key={dialect.id}
+              delay={index * 60}
+              className="ruled-cell h-full"
+            >
+              <DialectCard name={dialect.name} formUrl={dialect.formUrl} />
+            </Reveal>
+          ))}
+        </RuledGrid>
+      </section>
     </div>
   );
 }

--- a/himvirasat-frontend/app/(public)/datasets/page.tsx
+++ b/himvirasat-frontend/app/(public)/datasets/page.tsx
@@ -1,108 +1,91 @@
-import Image from "next/image";
+import type { Metadata } from "next";
 import Link from "next/link";
-import { SiGithub } from "@icons-pack/react-simple-icons";
 
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-  CardFooter,
-} from "@/components/ui/card";
+import { Eyebrow } from "@/components/mistral/eyebrow";
+import { PixelIcon } from "@/components/mistral/pixel-icon";
+import { RuledGrid } from "@/components/mistral/ruled-grid";
+import { SectionHeading } from "@/components/mistral/section-heading";
+import { TakriMosaic } from "@/components/mistral/takri-mosaic";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { datasets } from "@/lib/datasets/dataset-utils";
+import { devToTankri } from "@/lib/transliteration/devToTankri";
+
+export const metadata: Metadata = {
+  title: "Datasets",
+  description: "Download open, versioned Himachali translation datasets.",
+};
 
 export default function DatasetsPage() {
   return (
-    <div className="relative min-h-screen overflow-hidden text-foreground">
-      {/* Background Image */}
-      <div className="absolute inset-0">
-        <Image
-          src="/mountains1.png"
-          alt="Mountain background"
-          fill
-          className="object-cover"
-          priority
-          sizes="100vw"
+    <div>
+      <section className="mx-auto w-full max-w-content px-6 pt-20 pb-14 md:pt-28 lg:px-10">
+        <SectionHeading
+          as="h1"
+          align="left"
+          eyebrow="Datasets"
+          nativeEcho={devToTankri("आंकड़े")}
+          title="Open Himachali language datasets"
+          description="Curated linguistic datasets preserving Himachali dialects, published for research, NLP, and cultural documentation."
         />
-      </div>
+      </section>
 
-      {/* Overlay */}
-      <div className="absolute inset-0 bg-white/60 dark:bg-black/85" />
+      <TakriMosaic variant="band" seed={31} />
 
-      <main className="relative z-10 min-h-screen flex items-center">
-        <div className="max-w-6xl px-6 sm:px-10 w-full">
-          <span className="uppercase tracking-widest text-xs opacity-70 font-semibold">
-            Language & Culture
-          </span>
+      <section className="mx-auto w-full max-w-content px-6 pt-14 pb-24 md:pb-32 lg:px-10">
+        <RuledGrid cols={2}>
+          {datasets.map((dataset) => (
+            <article key={dataset.id} className="ruled-cell flex flex-col p-8">
+              <div className="flex flex-wrap items-baseline justify-between gap-3">
+                <h2 className="text-title">{dataset.name}</h2>
+                <Eyebrow className="text-verdant">
+                  {dataset.version}
+                </Eyebrow>
+              </div>
+              <p className="text-body-sm text-muted-foreground mt-1">
+                {dataset.language}
+              </p>
+              <p className="text-body-sm text-muted-foreground mt-4 flex-1">
+                Open, structured vocabulary data suitable for linguistic
+                research, NLP training, and documentation.
+              </p>
+              <div className="mt-8 flex flex-wrap gap-2">
+                <Button asChild>
+                  <a href={dataset.datasetLink} target="_blank" rel="noreferrer">
+                    Download ZIP
+                  </a>
+                </Button>
+                <Button asChild variant="secondary">
+                  <a href={dataset.kaggleLink} target="_blank" rel="noreferrer">
+                    Kaggle
+                  </a>
+                </Button>
+                <Button asChild variant="ghost">
+                  <a href={dataset.githubLink} target="_blank" rel="noreferrer">
+                    GitHub
+                    <PixelIcon name="arrow-up-right" className="size-4" />
+                  </a>
+                </Button>
+              </div>
+            </article>
+          ))}
 
-          <h1 className="mt-2 text-4xl md:text-5xl font-semibold">Datasets</h1>
-
-          <p className="mt-4 text-lg max-w-xl opacity-80 leading-relaxed">
-            Download curated linguistic datasets preserving Himachali dialects
-            for research, NLP, and cultural documentation.
-          </p>
-
-          <div className="mt-12 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {datasets.map((dataset) => (
-              <Card
-                key={dataset.id}
-                className="bg-background/80 backdrop-blur-md shadow-xl border border-border/50"
-              >
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <CardTitle className="text-lg">{dataset.name}</CardTitle>
-                    <Badge variant="secondary">{dataset.version}</Badge>
-                  </div>
-                  <CardDescription>{dataset.language}</CardDescription>
-                </CardHeader>
-
-                <CardContent>
-                  <p className="text-sm text-muted-foreground">
-                    Open-source structured vocabulary dataset suitable for
-                    linguistic research, NLP training, and documentation.
-                  </p>
-                </CardContent>
-
-                <CardFooter className="flex flex-col gap-3">
-                  {/* Download ZIP */}
-                  <Button
-                    asChild
-                    className="w-full bg-green-500 hover:bg-green-600 text-white"
-                  >
-                    <Link href={dataset.datasetLink} target="_blank">
-                      Download Dataset (ZIP)
-                    </Link>
-                  </Button>
-
-                  {/* Kaggle */}
-                  <Button asChild variant="outline" className="w-full">
-                    <Link href={dataset.kaggleLink} target="_blank">
-                      View on Kaggle
-                    </Link>
-                  </Button>
-
-                  <Button
-                    asChild
-                    variant="outline"
-                    className="w-full flex items-center justify-center gap-2 
-                               bg-white dark:bg-zinc-900 
-                               hover:bg-zinc-100 dark:hover:bg-zinc-800
-                               border border-border"
-                  >
-                    <Link href={dataset.githubLink} target="_blank">
-                      <SiGithub size={16} />
-                      View on GitHub
-                    </Link>
-                  </Button>
-                </CardFooter>
-              </Card>
-            ))}
-          </div>
-        </div>
-      </main>
+          <Link
+            href="/contribute"
+            className="ruled-cell hover:bg-secondary group flex flex-col p-8 transition-colors"
+          >
+            <h2 className="text-title text-muted-foreground">
+              More datasets in progress
+            </h2>
+            <p className="text-body-sm text-muted-foreground mt-2 flex-1">
+              Contribute sentences in your dialect to help publish the next one.
+            </p>
+            <PixelIcon
+              name="chevron-right"
+              className="text-muted-foreground mt-8 size-4 transition-transform duration-300 group-hover:translate-x-1"
+            />
+          </Link>
+        </RuledGrid>
+      </section>
     </div>
   );
 }

--- a/himvirasat-frontend/app/(public)/layout.tsx
+++ b/himvirasat-frontend/app/(public)/layout.tsx
@@ -1,5 +1,6 @@
-import Navbar from "@/components/layout/Navbar";
 import Footer from "@/components/layout/Footer";
+import Navbar from "@/components/layout/Navbar";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 export default function PublicLayout({
   children,
@@ -7,12 +8,19 @@ export default function PublicLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <TooltipProvider>
+      <a
+        href="#content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-background focus:px-3 focus:py-2"
+      >
+        Skip to content
+      </a>
+
       <Navbar />
-
-      <main>{children}</main>
-
+      <main id="content" className="min-h-screen pt-16">
+        {children}
+      </main>
       <Footer />
-    </>
+    </TooltipProvider>
   );
 }

--- a/himvirasat-frontend/app/(public)/page.tsx
+++ b/himvirasat-frontend/app/(public)/page.tsx
@@ -1,129 +1,397 @@
-import Image from "next/image";
 import Link from "next/link";
-import {
-  HeartIcon,
-  PencilSquareIcon,
-  ArrowDownTrayIcon,
-} from "@heroicons/react/24/outline";
+
+import { ArrowRow } from "@/components/mistral/arrow-row";
+import { DialectMarquee } from "@/components/mistral/dialect-marquee";
+import { Eyebrow } from "@/components/mistral/eyebrow";
+import { Hero } from "@/components/mistral/hero";
+import { InkBand } from "@/components/mistral/ink-band";
+import { PixelIcon, type PixelIconName } from "@/components/mistral/pixel-icon";
+import { RuledCell, RuledGrid } from "@/components/mistral/ruled-grid";
+import { SectionHeading } from "@/components/mistral/section-heading";
+import { StickyRailSection } from "@/components/mistral/sticky-rail-section";
+import { TakriMosaic } from "@/components/mistral/takri-mosaic";
 import { Button } from "@/components/ui/button";
-import { SiGithub } from "@icons-pack/react-simple-icons";
-const actionButtonClass =
-  "h-14 w-60 gap-3 rounded-full px-6 text-sm font-medium " +
-  "bg-white/95 text-gray-900 " +
-  "dark:bg-zinc-900 dark:text-zinc-100 " +
-  "shadow-sm ring-1 ring-black/10 dark:ring-white/10 " +
-  "backdrop-blur-sm transition " +
-  "hover:bg-white dark:hover:bg-zinc-800 hover:shadow-md";
+import { dialectsConfig } from "@/lib/dialects/dialect-config";
+import { site } from "@/lib/site";
+import { devToTankri } from "@/lib/transliteration/devToTankri";
+
+const shell = "mx-auto w-full max-w-content px-6 lg:px-10";
+
+/*
+ * TODO(copy): these are the honest, checkable claims we can make today —
+ * each points at a feature that actually exists. Replace with dated news
+ * entries once the project has any.
+ */
+/* The Mandeali item is promoted into the hero's right column, so it is
+   deliberately absent here rather than shown twice. */
+const FEATURED = [
+  {
+    label: "Devanagari and Takri, both directions",
+    description: "Convert between the two scripts in the browser.",
+    href: "/tools/transliterator",
+  },
+  {
+    label: "Translation datasets are public",
+    description: "Versioned, downloadable, free to use in research.",
+    href: "/datasets",
+  },
+];
+
+/* Real Hindi words, transliterated live by the site's own converter. */
+const SCRIPT_SAMPLES = [
+  { deva: "पहाड़", gloss: "mountain" },
+  { deva: "घर", gloss: "house" },
+  { deva: "पानी", gloss: "water" },
+  { deva: "रास्ता", gloss: "path" },
+  { deva: "विरासत", gloss: "heritage" },
+  { deva: "हिमाचल", gloss: "Himachal" },
+];
+
+const ARCHIVE: Array<{
+  icon: PixelIconName;
+  title: string;
+  description: string;
+  href: string;
+}> = [
+  {
+    icon: "book",
+    title: "Vocabulary",
+    description: "Living dictionaries, searchable by dialect and by word.",
+    href: "/vocabulary",
+  },
+  {
+    icon: "stack",
+    title: "Datasets",
+    description: "Open Hindi to dialect translation pairs, versioned.",
+    href: "/datasets",
+  },
+  {
+    icon: "swap",
+    title: "Transliterator",
+    description: "Devanagari to Takri and back, entirely in the browser.",
+    href: "/tools/transliterator",
+  },
+  {
+    icon: "map",
+    title: "Dialects",
+    description: "One archive per dialect, opened as contributors arrive.",
+    href: "/vocabulary",
+  },
+  {
+    icon: "quill",
+    title: "Contribute",
+    description: "Write sentences in your dialect. No technical skill needed.",
+    href: "/contribute",
+  },
+  {
+    icon: "people",
+    title: "Community",
+    description: "Built in the open by people from across Himachal.",
+    href: "/about",
+  },
+];
+
+/* TODO(copy): confirm the framing of these four with the maintainers. */
+const REASONS = [
+  {
+    title: "Nobody else is collecting this",
+    body: "Himachali dialects sit outside every major language dataset. If they are not written down here, they are not written down anywhere.",
+  },
+  {
+    title: "No technical skill required",
+    body: "Write an everyday sentence in your dialect and its Hindi translation. That is the whole contribution.",
+  },
+  {
+    title: "Open from the first line",
+    body: "Every word collected is published under an open licence, free for researchers and model builders alike.",
+  },
+  {
+    title: "Two scripts, one record",
+    body: "Entries carry both Devanagari and Takri, so the older script stays legible to the next generation.",
+  },
+];
+
+const WAYS = [
+  {
+    title: "Contribute words",
+    body: "Add vocabulary and parallel sentences in the dialect you grew up speaking.",
+    href: "/contribute",
+    cta: "Start contributing",
+  },
+  {
+    title: "Verify submissions",
+    body: "Native speakers review what others have written and confirm spelling, sense and usage.",
+    href: "/contribute",
+    cta: "Join the review",
+  },
+  {
+    title: "Build with the data",
+    body: "Download the datasets and use them in research, tooling, or multilingual models.",
+    href: "/datasets",
+    cta: "Browse datasets",
+  },
+];
 
 export default function Home() {
   return (
-    <div className="relative min-h-screen overflow-hidden">
-      <div
-        className="absolute inset-0 bg-cover bg-center"
-        style={{ backgroundImage: "url('/mountains1.png')" }}
-      />
-      <div className="absolute inset-0 bg-white/60 dark:bg-black/85" />
+    <>
+      {/* ── Hero ─────────────────────────────────────────────────────── */}
+      <Hero />
 
-      <main className="relative mx-auto min-h-screen max-w-4xl px-6 py-24 sm:px-12">
-        <div className="flex flex-col items-center text-center">
-          <Image
-            src="/virasat.png"
-            alt="HimVirasat logo"
-            width={84}
-            height={84}
-            priority
-            className="rounded-2xl"
-          />
+      {/* ── Featured ─────────────────────────────────────────────────── */}
+      <section className={`${shell} py-20 md:py-28`}>
+        <Eyebrow size="lg" className="mb-6">
+          Featured
+        </Eyebrow>
+        <ul className="border-border flex flex-col border-t">
+          {FEATURED.map((item) => (
+            <li key={item.href} className="border-border border-b">
+              <ArrowRow
+                href={item.href}
+                label={item.label}
+                description={item.description}
+              />
+            </li>
+          ))}
+        </ul>
+      </section>
 
-          <h1 className="mt-6 bg-linear-to-r from-emerald-700 via-green-700 to-amber-600 bg-clip-text text-5xl font-semibold tracking-tight text-transparent">
-            HimVirasat
-          </h1>
+      {/* ── Dialect marquee ──────────────────────────────────────────── */}
+      <DialectMarquee />
 
-          <p className="mt-4 max-w-2xl text-lg leading-8 text-zinc-800 dark:text-zinc-200">
-            A community-driven initiative to preserve Himachal Pradesh’s
-            languages, dialects, traditions, and cultural memory — and bring
-            them into the digital age.
-          </p>
+      {/* ── Dialect strip ────────────────────────────────────────────── */}
+      <section className="border-border border-b">
+        <div className={`${shell} py-10`}>
+          <Eyebrow className="mb-6">Dialects in the archive</Eyebrow>
+          {/* Two columns, not four: the hairlines are drawn by a 1px gap
+              over the container colour, so any cell short of a full row
+              would render as a solid grey block. Cell count here is
+              dialectsConfig.length + 1. */}
+          <div className="bg-border grid gap-px sm:grid-cols-2">
+            {dialectsConfig.map((dialect) => (
+              <Link
+                key={dialect.id}
+                href={`/vocabulary/${dialect.id}`}
+                className="ruled-cell hover:bg-secondary flex flex-col gap-1 px-5 py-6 transition-colors"
+              >
+                <span className="text-title">{dialect.title}</span>
+                {dialect.nativeName && (
+                  <span lang="hi" className="font-deva text-muted-foreground">
+                    {dialect.nativeName}
+                  </span>
+                )}
+                <span className="text-body-sm text-muted-foreground">
+                  {dialect.subtitle}
+                </span>
+              </Link>
+            ))}
+            {/* Only published dialects are listed above. Six more are open
+                for collection but have no vocabulary behind them yet, so
+                they are named on /contribute rather than here. */}
+            <Link
+              href="/contribute"
+              className="ruled-cell hover:bg-secondary flex flex-col gap-1 px-5 py-6 transition-colors"
+            >
+              <span className="text-title text-muted-foreground">
+                Six more collecting
+              </span>
+              <span className="text-body-sm text-muted-foreground">
+                Kangri, Kullvi, Mahasuvi, Kinnauri and more are open for
+                contributions.
+              </span>
+            </Link>
+          </div>
         </div>
+      </section>
 
-        <section className="mt-16 rounded-2xl bg-white/80 p-8 shadow-lg backdrop-blur dark:bg-zinc-900/70">
-          <h2 className="text-2xl font-semibold text-emerald-800 dark:text-emerald-400">
-            Open Translation Datasets for Himachali Dialects
+      {/* ── Script showcase ──────────────────────────────────────────── */}
+      <section className={`${shell} py-20 md:py-28`}>
+        <SectionHeading
+          eyebrow="Two scripts"
+          title="Devanagari today, Takri kept alive."
+          description="Takri was the working script of the western Himalaya before Devanagari displaced it. Every entry in the archive carries both."
+        />
+        <RuledGrid cols="2-3" className="mt-14">
+          {SCRIPT_SAMPLES.map((sample) => (
+            <RuledCell key={sample.deva} className="p-8">
+              <Eyebrow>{sample.gloss}</Eyebrow>
+              <p
+                lang="hi"
+                className="font-deva mt-5 text-4xl leading-none"
+              >
+                {sample.deva}
+              </p>
+              <p
+                aria-hidden
+                className="font-takri text-verdant mt-4 text-4xl leading-none"
+              >
+                {devToTankri(sample.deva)}
+              </p>
+            </RuledCell>
+          ))}
+        </RuledGrid>
+        <div className="mt-10 flex justify-center">
+          <Button asChild variant="secondary">
+            <Link href="/tools/transliterator">Open the transliterator</Link>
+          </Button>
+        </div>
+      </section>
+
+      {/* ── Six-up archive grid ──────────────────────────────────────── */}
+      <section className={`${shell} py-20 md:py-28`}>
+        <SectionHeading
+          eyebrow="The archive"
+          title="Everything in one place."
+        />
+        <RuledGrid cols="2-3" className="mt-14">
+          {ARCHIVE.map((item) => (
+            <Link
+              key={item.title}
+              href={item.href}
+              className="ruled-cell hover:bg-secondary group flex flex-col p-8 transition-colors"
+            >
+              <PixelIcon name={item.icon} className="text-verdant size-7" />
+              <h3 className="text-title mt-5">{item.title}</h3>
+              <p className="text-body-sm text-muted-foreground mt-2 flex-1">
+                {item.description}
+              </p>
+              <PixelIcon
+                name="chevron-right"
+                className="text-muted-foreground mt-6 size-4 transition-transform duration-300 group-hover:translate-x-1"
+              />
+            </Link>
+          ))}
+        </RuledGrid>
+      </section>
+
+      {/* ── Deep dives ───────────────────────────────────────────────── */}
+      <StickyRailSection
+        eyebrow="Vocabulary"
+        railTitle="Living dictionaries, one dialect at a time."
+        railFooter="Search by word, by sense, or by dialect."
+      >
+        <div className="border-border flex flex-col gap-6 border-b px-6 py-16 lg:px-12 lg:py-24">
+          <h2 className="text-display-md max-w-2xl text-balance">
+            A word survives if somebody writes it down.
           </h2>
-
-          <p className="mt-4 text-base leading-7 text-zinc-700 dark:text-zinc-300">
-            We are building open, structured Hindi ↔ Himachali dialect
-            translation datasets by collecting parallel sentences written by
-            native speakers. Contributors simply write everyday sentences in
-            their dialect along with Hindi translations. No technical knowledge
-            required.
+          <p className="text-body-lg text-muted-foreground max-w-2xl">
+            Each dialect gets its own searchable archive: the word, how it is
+            said, what it means, and the Hindi it maps to. Entries come from
+            native speakers and are reviewed by native speakers.
           </p>
+          <div>
+            <Button asChild variant="secondary">
+              <Link href="/vocabulary">Search the vocabulary</Link>
+            </Button>
+          </div>
+        </div>
+      </StickyRailSection>
 
-          <p className="mt-4 text-base leading-7 text-zinc-700 dark:text-zinc-300">
-            These datasets will be freely available for research and used to
-            fine-tune multilingual AI models, ensuring Himachali languages are
-            not left behind in the digital age.
+      <StickyRailSection
+        eyebrow="Datasets"
+        railTitle="Open translation data, versioned and free."
+        railFooter="Published for research and model training."
+      >
+        <div className="border-border flex flex-col gap-6 border-b px-6 py-16 lg:px-12 lg:py-24">
+          <h2 className="text-display-md max-w-2xl text-balance">
+            Himachali dialects belong in the models too.
+          </h2>
+          <p className="text-body-lg text-muted-foreground max-w-2xl">
+            Contributions are compiled into structured Hindi to dialect
+            translation pairs and published openly, so that the languages of
+            Himachal are represented wherever multilingual systems are built.
           </p>
-        </section>
+          <div>
+            <Button asChild variant="secondary">
+              <Link href="/datasets">Browse the datasets</Link>
+            </Button>
+          </div>
+        </div>
+      </StickyRailSection>
 
-        <div className="mt-12 flex flex-col items-center gap-4 sm:flex-row sm:flex-wrap sm:justify-center">
-          <Button asChild className={actionButtonClass}>
-            <Link
-              href="https://discord.gg/PgJWcFXRTB"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Image
-                src="/virasat.png"
-                alt="HimVirasat Discord"
-                width={36}
-                height={36}
-                className="rounded-full"
-              />
-              HimVirasat Discord
-            </Link>
-          </Button>
+      <StickyRailSection
+        eyebrow="Tools"
+        railTitle="Script tooling that runs in the browser."
+        railFooter="No account, no upload, no server round trip."
+      >
+        <div className="border-border flex flex-col gap-6 border-b px-6 py-16 lg:px-12 lg:py-24">
+          <h2 className="text-display-md max-w-2xl text-balance">
+            Read Takri without learning Takri first.
+          </h2>
+          <p className="text-body-lg text-muted-foreground max-w-2xl">
+            The transliterator maps Devanagari to Takri and back, character by
+            character, so older manuscripts and inscriptions stay approachable
+            to anyone who can read Hindi.
+          </p>
+          <div>
+            <Button asChild variant="secondary">
+              <Link href="/tools/transliterator">Open the transliterator</Link>
+            </Button>
+          </div>
+        </div>
+      </StickyRailSection>
 
-          <Button asChild className={actionButtonClass}>
-            <Link
-              href="https://discord.gg/wHjT3vMAVx"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Image
-                src="/hpdiscord.png"
-                alt="Himachal Pradesh Discord"
-                width={36}
-                height={36}
-                className="rounded-full"
-              />
-              HP Discord Community
-            </Link>
-          </Button>
+      {/* ── Why contribute ───────────────────────────────────────────── */}
+      <section className={`${shell} py-20 md:py-28`}>
+        <SectionHeading eyebrow="Why contribute" title="Four honest reasons." />
+        <RuledGrid cols="2-4" className="mt-14">
+          {REASONS.map((reason) => (
+            <RuledCell key={reason.title} className="p-8">
+              <h3 className="text-title text-balance">{reason.title}</h3>
+              <p className="text-body-sm text-muted-foreground mt-3">
+                {reason.body}
+              </p>
+            </RuledCell>
+          ))}
+        </RuledGrid>
+      </section>
 
-          <Button asChild className={`${actionButtonClass}`}>
-            <Link href="/datasets">
-              <ArrowDownTrayIcon className="h-16 w-16 scale-150" /> Datasets
-            </Link>
+      {/* ── Ways to help ─────────────────────────────────────────────── */}
+      <InkBand>
+        <div className={`${shell} py-20 md:py-28`}>
+          <SectionHeading
+            eyebrow="Ways to help"
+            title="Three ways in, whatever you bring."
+            className="mb-14"
+          />
+          <div className="bg-ink-border grid gap-px sm:grid-cols-3">
+            {WAYS.map((way) => (
+              <div key={way.title} className="bg-ink flex flex-col p-8 lg:p-10">
+                <h3 className="text-title">{way.title}</h3>
+                <p className="text-body-sm mt-3 flex-1 text-muted-foreground">
+                  {way.body}
+                </p>
+                <div className="mt-8">
+                  <Button asChild variant="secondary">
+                    <Link href={way.href}>{way.cta}</Link>
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </InkBand>
+
+      {/* ── Closing ──────────────────────────────────────────────────── */}
+      <section className={`${shell} py-24 md:py-32`}>
+        <SectionHeading
+          as="h2"
+          title="Preserve your mother tongue."
+          description={`${site.name} is an open effort. The archive grows only as fast as people write into it.`}
+        />
+        <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
+          <Button asChild size="lg">
+            <Link href="/contribute">Start contributing</Link>
           </Button>
-          <Button asChild className={`${actionButtonClass}`}>
-            <Link href="/contribute">
-              <HeartIcon className="h-16 w-16 scale-150 text-red-500 fill-red-500" />
-              <span>Contribute</span>
-            </Link>
-          </Button>
-          <Button asChild className={`${actionButtonClass}`}>
-            <Link href="/vocabulary">
-              <PencilSquareIcon className="h-16 w-16 scale-150" />
-              Vocabulary
-            </Link>
+          <Button asChild size="lg" variant="secondary">
+            <a href={site.links.repo} target="_blank" rel="noreferrer">
+              Read the source
+            </a>
           </Button>
         </div>
-        <footer className="mt-20 text-center text-md text-black dark:text-zinc-400">
-          HimVirasat is an open, community-driven effort to preserve Himachal’s
-          heritage for future generations.
-        </footer>
-      </main>
-    </div>
+      </section>
+
+      <TakriMosaic variant="band" seed={19} />
+    </>
   );
 }

--- a/himvirasat-frontend/app/(public)/tools/page.tsx
+++ b/himvirasat-frontend/app/(public)/tools/page.tsx
@@ -1,48 +1,58 @@
-import Image from "next/image";
-import DialectLink from "@/components/vocabulary/DialectLink";
+import type { Metadata } from "next";
+
+import { PixelIcon } from "@/components/mistral/pixel-icon";
+import { RuledGrid } from "@/components/mistral/ruled-grid";
+import { SectionHeading } from "@/components/mistral/section-heading";
+import { ToolCard } from "@/components/tools/tool-card";
+import { site } from "@/lib/site";
+import { devToTankri } from "@/lib/transliteration/devToTankri";
+
+export const metadata: Metadata = {
+  title: "Language Tools",
+};
 
 export default function ToolsPage() {
   return (
-    <div className="relative min-h-screen overflow-hidden text-slate-900 dark:text-slate-100">
-      {/* Background */}
-      <div className="absolute inset-0">
-        <Image
-          src="/mountains1.png"
-          alt="Mountain background"
-          fill
-          className="object-cover"
-          priority
-          sizes="100vw"
+    <div className="mx-auto w-full max-w-content px-6 py-20 md:py-28 lg:px-10">
+      <SectionHeading
+        as="h1"
+        align="left"
+        eyebrow="Tools"
+        nativeEcho={devToTankri("उपकरण")}
+        title="Language tools"
+        description="Utilities for working with scripts, datasets, and the day-to-day tasks of language preservation."
+      />
+
+      <RuledGrid cols={2} className="mt-14">
+        <ToolCard
+          href="/tools/transliterator"
+          title="Transliterator"
+          description="Convert between Devanagari and Takri, the script once used across Himachal."
+          glyph="𑚀"
         />
-      </div>
 
-      {/* Overlay */}
-      <div className="absolute inset-0 bg-white/60 dark:bg-black/85" />
-
-      {/* Content */}
-      <main className="relative z-10 min-h-screen flex items-center">
-        <div className="max-w-5xl px-6 sm:px-10">
-          <span className="uppercase tracking-widest text-xs opacity-70 font-semibold">
-            Tools
+        <a
+          href={`${site.links.repo}/issues`}
+          target="_blank"
+          rel="noreferrer"
+          className="ruled-cell hover:bg-secondary group flex h-full flex-col p-8 transition-colors"
+        >
+          <span
+            aria-hidden
+            className="bg-secondary border-border mb-6 grid size-14 place-items-center border border-dashed"
+          >
+            <PixelIcon name="plus" className="text-muted-foreground" />
           </span>
-
-          <h1 className="mt-2 text-4xl md:text-5xl font-semibold">Tools</h1>
-
-          <p className="mt-4 text-lg max-w-xl opacity-80 leading-relaxed">
-            Utility tools to assist contributors in working with scripts,
-            datasets, and language preservation tasks.
+          <h2 className="text-title">Propose a tool</h2>
+          <p className="text-body-sm text-muted-foreground mt-2 flex-1">
+            Open an issue on GitHub with your idea.
           </p>
-
-          {/* Tools Grid */}
-          <div className="mt-10 grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-xl">
-            <DialectLink
-              href="/tools/transliterator"
-              title="Transliterator"
-              subtitle="Convert between Devanagari and Tankri scripts."
-            />
-          </div>
-        </div>
-      </main>
+          <PixelIcon
+            name="arrow-up-right"
+            className="text-muted-foreground mt-6 size-4 transition-transform duration-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+          />
+        </a>
+      </RuledGrid>
     </div>
   );
 }

--- a/himvirasat-frontend/app/(public)/tools/transliterator/page.tsx
+++ b/himvirasat-frontend/app/(public)/tools/transliterator/page.tsx
@@ -1,53 +1,31 @@
-import Image from "next/image";
+import type { Metadata } from "next";
+
+import { SectionHeading } from "@/components/mistral/section-heading";
 import Transliterator from "@/components/transliterator/Transliterator";
+
+export const metadata: Metadata = {
+  title: "Devanagari ⇄ Takri Transliterator",
+};
 
 export default function TransliteratorPage() {
   return (
-    <div className="relative min-h-screen overflow-hidden text-slate-900 dark:text-slate-100">
-      {/* Background */}
-      <div className="absolute inset-0">
-        <Image
-          src="/mountains1.png"
-          alt="Mountain background"
-          fill
-          className="object-cover"
-          priority
-          sizes="100vw"
-        />
+    <div className="mx-auto w-full max-w-content px-6 py-20 md:py-28 lg:px-10">
+      <SectionHeading
+        as="h1"
+        align="left"
+        eyebrow="Tools"
+        title="Devanagari ⇄ Takri"
+        description="Takri served as a chancery script across the western Himalaya before Devanagari replaced it."
+      />
+
+      <div className="mt-14">
+        <Transliterator />
       </div>
 
-      {/* Overlay */}
-      <div className="absolute inset-0 bg-white/60 dark:bg-black/85" />
-
-      {/* Content */}
-      <main className="relative z-10 min-h-screen flex items-center justify-center px-6 pt-20">
-        <div className="w-full max-w-6xl">
-          <span className="uppercase tracking-widest text-xs opacity-70 font-semibold">
-            Tools
-          </span>
-
-          <h1 className="mt-2 text-4xl md:text-5xl font-semibold">
-            Transliteration
-          </h1>
-
-          <p className="mt-4 text-lg max-w-xl opacity-80 leading-relaxed">
-            Convert text between Devanagari and Tankri scripts for contribution
-            and verification.
-          </p>
-
-          <div className="mt-10">
-            <Transliterator />
-          </div>
-
-          {/* Font Support Note */}
-          <p className="mt-6 text-xs opacity-60 max-w-xl leading-relaxed">
-            Tankri characters may not display correctly on some systems due to
-            limited font support. If characters appear as blank boxes, please
-            install a Unicode font that supports Tankri (e.g., Noto Sans
-            Tankri).
-          </p>
-        </div>
-      </main>
+      <p className="text-body-sm text-muted-foreground mt-6 max-w-xl">
+        Takri text you copy will need a Takri-capable font in the destination
+        app.
+      </p>
     </div>
   );
 }

--- a/himvirasat-frontend/app/(public)/vocabulary/[dialect]/page.tsx
+++ b/himvirasat-frontend/app/(public)/vocabulary/[dialect]/page.tsx
@@ -1,22 +1,38 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import Image from "next/image";
 import { Suspense } from "react";
-import {
-  dialectToBackground,
-  availableDialectsArray,
-} from "@/lib/dialects/dialect-config";
+
+import { SectionHeading } from "@/components/mistral/section-heading";
 import VocabularySearch from "@/components/vocabulary/VocabularySearch";
+import {
+  availableDialectsArray,
+  dialectsConfig,
+} from "@/lib/dialects/dialect-config";
+import { devToTankri } from "@/lib/transliteration/devToTankri";
+
+function capitalize(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export async function generateStaticParams() {
+  return availableDialectsArray.map((dialect) => ({ dialect }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ dialect: string }>;
+}): Promise<Metadata> {
+  const { dialect } = await params;
+  return { title: `${capitalize(dialect)} Vocabulary` };
+}
 
 function VocabularySearchSkeleton() {
   return (
-    <div className="w-full max-w-5xl mx-auto space-y-6">
-      <div className="flex gap-3 justify-center">
-        <div className="flex-1 max-w-2xl h-14 bg-white/10 rounded-xl animate-pulse" />
-        <div className="h-14 w-24 bg-white/10 rounded-xl animate-pulse" />
-      </div>
-
+    <div className="w-full space-y-6">
+      <div className="bg-muted h-14 max-w-2xl animate-pulse rounded-md" />
       {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="h-28 bg-white/10 rounded-xl animate-pulse" />
+        <div key={i} className="bg-muted h-28 animate-pulse" />
       ))}
     </div>
   );
@@ -33,43 +49,28 @@ export default async function DialectPage({
     notFound();
   }
 
-  const background = dialectToBackground[dialect];
+  const config = dialectsConfig.find((d) => d.id === dialect);
 
   return (
-    <div className="relative min-h-screen text-slate-100 pt-10">
-      <div className="fixed inset-0 -z-20 overflow-hidden">
-        <Image
-          src={background}
-          alt={`${dialect} background`}
-          fill
-          className="object-cover"
-          priority
-          sizes="100vw"
+    <main className="mx-auto w-full max-w-content px-6 py-20 md:py-28 lg:px-10">
+      <header>
+        <SectionHeading
+          as="h1"
+          align="left"
+          eyebrow="Vocabulary"
+          title={config?.title ?? capitalize(dialect)}
+          nativeEcho={
+            config?.nativeName ? devToTankri(config.nativeName) : undefined
+          }
+          description={`Explore the vocabulary and cultural expressions of ${config?.title ?? capitalize(dialect)}.`}
         />
+      </header>
+
+      <div className="mt-10">
+        <Suspense fallback={<VocabularySearchSkeleton />}>
+          <VocabularySearch dialect={dialect} />
+        </Suspense>
       </div>
-
-      <div className="fixed inset-0 -z-10 bg-black/30" />
-
-      <main className="min-h-screen flex justify-center px-4 md:px-6 py-12">
-        <div className="w-full max-w-5xl bg-black/50 rounded-2xl p-6 md:p-10 border border-white/10 backdrop-blur-md">
-          <header className="mb-10">
-            <span className="uppercase tracking-widest text-xs text-emerald-400 font-bold">
-              Himachali Dialect
-            </span>
-            <h1 className="mt-2 text-4xl md:text-5xl font-semibold capitalize tracking-tight">
-              {dialect}
-            </h1>
-            <p className="mt-4 text-slate-300 text-lg leading-relaxed">
-              Explore the vocabulary and cultural expressions of{" "}
-              <span className="text-white font-medium">{dialect}</span>.
-            </p>
-          </header>
-
-          <Suspense fallback={<VocabularySearchSkeleton />}>
-            <VocabularySearch dialect={dialect} />
-          </Suspense>
-        </div>
-      </main>
-    </div>
+    </main>
   );
 }

--- a/himvirasat-frontend/app/(public)/vocabulary/page.tsx
+++ b/himvirasat-frontend/app/(public)/vocabulary/page.tsx
@@ -1,51 +1,71 @@
+import type { Metadata } from "next";
 import Link from "next/link";
-import Image from "next/image";
-import DialectLink from "@/components/vocabulary/DialectLink";
-import { dialectsConfig } from "@/lib/dialects/dialect-config"; // Import the config
+
+import { PixelIcon } from "@/components/mistral/pixel-icon";
+import { RuledGrid } from "@/components/mistral/ruled-grid";
+import { SectionHeading } from "@/components/mistral/section-heading";
+import { dialectsConfig } from "@/lib/dialects/dialect-config";
+import { devToTankri } from "@/lib/transliteration/devToTankri";
+
+export const metadata: Metadata = {
+  title: "Himachali Vocabulary",
+  description: "Search living dictionaries of Himachali dialects.",
+};
 
 export default function VocabularyPage() {
   return (
-    <div className="relative min-h-screen overflow-hidden text-slate-900 dark:text-slate-100">
-      <div className="absolute inset-0">
-        <Image
-          src="/mountains1.png"
-          alt="Mountain background"
-          fill
-          className="object-cover"
-          priority
-          sizes="100vw"
-        />
-      </div>
+    <main className="mx-auto w-full max-w-content px-6 py-20 md:py-28 lg:px-10">
+      <SectionHeading
+        as="h1"
+        align="left"
+        eyebrow="Vocabulary"
+        nativeEcho={devToTankri("शब्दकोश")}
+        title="Living dictionaries"
+        description="Himachali dialects, their vocabulary, expressions, and the meanings they carry."
+      />
 
-      <div className="absolute inset-0 bg-white/60 dark:bg-black/85" />
+      <RuledGrid cols={2} className="mt-14">
+        {dialectsConfig.map((dialect) => (
+          <Link
+            key={dialect.id}
+            href={`/vocabulary/${dialect.id}`}
+            className="ruled-cell hover:bg-secondary group flex flex-col p-8 transition-colors"
+          >
+            <div className="flex flex-wrap items-baseline gap-x-3">
+              <h2 className="text-title">{dialect.title}</h2>
+              {dialect.nativeName && (
+                <span
+                  aria-hidden
+                  className="font-deva text-verdant text-lg"
+                >
+                  {dialect.nativeName}
+                </span>
+              )}
+            </div>
+            <p className="text-body-sm text-muted-foreground mt-2 flex-1">
+              {dialect.subtitle}
+            </p>
+            <PixelIcon
+              name="chevron-right"
+              className="text-muted-foreground mt-8 size-4 transition-transform duration-300 group-hover:translate-x-1"
+            />
+          </Link>
+        ))}
 
-      <main className="relative z-10 min-h-screen flex items-center">
-        <div className="max-w-5xl px-6 sm:px-10">
-          <span className="uppercase tracking-widest text-xs opacity-70 font-semibold">
-            Language & Culture
-          </span>
-
-          <h1 className="mt-2 text-4xl md:text-5xl font-semibold">
-            Vocabulary
-          </h1>
-
-          <p className="mt-4 text-lg max-w-xl opacity-80 leading-relaxed">
-            Explore Himachali dialects, their vocabulary, expressions, and
-            cultural meanings preserved from the hills.
+        <Link
+          href="/contribute"
+          className="ruled-cell hover:bg-secondary group flex flex-col p-8 transition-colors"
+        >
+          <h2 className="text-title text-muted-foreground">Your dialect next</h2>
+          <p className="text-body-sm text-muted-foreground mt-2 flex-1">
+            Contribute sentences to bring your dialect online.
           </p>
-
-          <div className="mt-10 grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-xl">
-            {dialectsConfig.map((dialect) => (
-              <DialectLink
-                key={dialect.id}
-                href={`/vocabulary/${dialect.id}`}
-                title={dialect.title}
-                subtitle={dialect.subtitle}
-              />
-            ))}
-          </div>
-        </div>
-      </main>
-    </div>
+          <PixelIcon
+            name="chevron-right"
+            className="text-muted-foreground mt-8 size-4 transition-transform duration-300 group-hover:translate-x-1"
+          />
+        </Link>
+      </RuledGrid>
+    </main>
   );
 }

--- a/himvirasat-frontend/app/apple-icon.tsx
+++ b/himvirasat-frontend/app/apple-icon.tsx
@@ -1,0 +1,61 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+/**
+ * Same snow-capped ridgeline as components/mistral/logo-mark.tsx and
+ * app/icon.tsx. Satori cannot import the React component, so the tile
+ * table is duplicated in all three — change one, change all three.
+ */
+const TILES: Array<[number, number, number]> = [
+  [2, 0, 0],
+  [1, 1, 1],
+  [2, 1, 1],
+  [0, 2, 2],
+  [1, 2, 2],
+  [2, 2, 2],
+  [3, 2, 3],
+  [0, 3, 4],
+  [1, 3, 4],
+  [2, 3, 3],
+  [3, 3, 4],
+];
+
+/** summit → base: glacier, sage, forest, pine, timber. */
+const PEAK = ["#7ec6c6", "#7fb69b", "#2e7358", "#1c5341", "#6e4e36"];
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#fbfbf8",
+        }}
+      >
+        {/* 4 x 36px tiles, centred in the 180px canvas with a 18px margin. */}
+        <div style={{ display: "flex", position: "relative", width: 144, height: 144 }}>
+          {TILES.map(([col, row, step]) => (
+            <div
+              key={`${col}-${row}`}
+              style={{
+                position: "absolute",
+                left: col * 36,
+                top: row * 36,
+                width: 36,
+                height: 36,
+                backgroundColor: PEAK[step],
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/himvirasat-frontend/app/globals.css
+++ b/himvirasat-frontend/app/globals.css
@@ -3,130 +3,753 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* ═══════════════════════════════════════════════════════════════════════
+   Warm off-white canvas, hairline-ruled grids, near-zero shadow, flame
+   accent ramp. Structure comes from 1px rules, not from fills or
+   elevation. Colour is decoration, never the only carrier of meaning.
+   ═══════════════════════════════════════════════════════════════════ */
+
 @theme inline {
+  /* ── Fonts ─────────────────────────────────────────────────────────
+     Inter carries body copy, Geist the display sizes, Space Mono
+     the uppercase eyebrows. Devanagari and Takri are content faces and
+     are never used for chrome. */
+  --font-sans:
+    var(--font-inter), ui-sans-serif, system-ui, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji";
+  --font-display:
+    var(--font-geist), var(--font-inter), ui-sans-serif, sans-serif;
+  --font-mono: var(--font-space-mono), ui-monospace, monospace;
+  --font-deva: var(--font-noto-serif-deva), Georgia, serif;
+  --font-takri: var(--font-noto-takri), sans-serif;
+
+  /* ── Type scale ────────────────────────────────────────────────────
+     Tracking is in em so it stays proportional across the ramp: -0.01em
+     on display sizes, +0.01/+0.02em on the small UI sizes. */
+  --text-display-xl: 3.5rem;
+  --text-display-xl--line-height: 1.05;
+  --text-display-xl--letter-spacing: -0.01em;
+  --text-display-xl--font-weight: 500;
+
+  --text-display-lg: 2.75rem;
+  --text-display-lg--line-height: 1.08;
+  --text-display-lg--letter-spacing: -0.01em;
+  --text-display-lg--font-weight: 500;
+
+  --text-display-md: 2rem;
+  --text-display-md--line-height: 1.15;
+  --text-display-md--letter-spacing: -0.01em;
+  --text-display-md--font-weight: 500;
+
+  --text-title: 1.5rem;
+  --text-title--line-height: 1.25;
+  --text-title--letter-spacing: -0.01em;
+  --text-title--font-weight: 500;
+
+  --text-label: 1rem;
+  --text-label--line-height: 1.5;
+  --text-label--letter-spacing: 0.01em;
+  --text-label--font-weight: 500;
+
+  --text-nav: 0.875rem;
+  --text-nav--line-height: 1.4;
+  --text-nav--letter-spacing: 0.02em;
+  --text-nav--font-weight: 500;
+
+  --text-body-lg: 1.25rem;
+  --text-body-lg--line-height: 1.6;
+  --text-body-lg--letter-spacing: -0.02em;
+
+  --text-body: 1rem;
+  --text-body--line-height: 1.6;
+  --text-body--letter-spacing: -0.01em;
+
+  --text-body-sm: 0.8125rem;
+  --text-body-sm--line-height: 1.55;
+
+  --text-eyebrow: 0.6875rem;
+  --text-eyebrow--line-height: 1.4;
+
+  --text-eyebrow-lg: 0.8125rem;
+  --text-eyebrow-lg--line-height: 1.4;
+
+  /* ── Containers and rhythm ─────────────────────────────────────────
+     1728px outer shell, 1360px ruled content band, 1024px prose. */
+  --container-shell: 108rem;
+  --container-content: 85rem;
+  --container-prose: 64rem;
+  --spacing-section: 10rem;
+
+  /* ── shadcn contract, re-pointed ───────────────────────────────────
+     The ui/ primitives read these, so changing them here restyles the
+     whole surface area including the admin dashboard. */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
-  --color-ring: var(--ring);
-  --color-input: var(--input);
-  --color-border: var(--border);
-  --color-destructive: var(--destructive);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-accent: var(--accent);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-primary: var(--primary);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-popover: var(--popover);
-  --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+
+  /* ── Surfaces beyond the shadcn contract ───────────────────────────
+     `surface-3` is the deepest warm tint (mosaic neutrals, table zebra).
+     `ink` is the full-bleed dark band; it stays dark in both themes. */
+  --color-surface-3: var(--surface-3);
+  --color-ink: #0a0a0c;
+  --color-ink-foreground: #fbfbf8;
+  --color-ink-border: #26262b;
+  --color-hairline-strong: var(--hairline-strong);
+
+  /* ── Deodar ramp ───────────────────────────────────────────────────
+     Himachal in three registers: forest green, glacial blue-green, and
+     the earth browns of kath-kuni timber. Fill-only — the ramp spans
+     both light and dark values, so glyphs sitting on a tile pick their
+     ink per tone (see components/mistral/takri-mosaic.tsx). When a green
+     must carry text, use `text-verdant`: the one theme-aware step, dark
+     enough for the cream canvas and light enough for the near-black. */
+  --color-pine-100: #7fb69b;
+  --color-pine-300: #4e9578;
+  --color-pine-500: #2e7358;
+  --color-pine-700: #1c5341;
+  --color-pine-900: #0f3a2e;
+
+  /* Glacial melt — the cool counterpoint, and the snow on the mark. */
+  --color-glacier-300: #7ec6c6;
+  --color-glacier-500: #3e9ca3;
+
+  /* Timber and slate — used sparingly, and for warning states. */
+  --color-clay-400: #a98363;
+  --color-clay-600: #6e4e36;
+
+  --color-verdant: var(--verdant);
+
+  /* ── Radii ─────────────────────────────────────────────────────────
+     Derived from --radius: sm 4 · md 6 · lg 8 · xl 12. Mosaic tiles and
+     ruled cells stay square and opt out entirely. */
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
-  --radius-4xl: calc(var(--radius) + 16px);
 }
 
+/* ── Light: warm off-white ──────────────────────────────────────────── */
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --radius: 0.5rem;
+
+  --background: #fbfbf8;
+  --foreground: #07070b;
+  --card: #fbfbf8;
+  --card-foreground: #07070b;
+  --popover: #ffffff;
+  --popover-foreground: #07070b;
+
+  /* Primary action is near-black, not a brand colour. */
+  --primary: #07070b;
+  --primary-foreground: #fbfbf8;
+  --secondary: #f5f4ef;
+  --secondary-foreground: #07070b;
+  --muted: #f5f4ef;
+  --muted-foreground: #5a5a63;
+  --accent: #f5f4ef;
+  --accent-foreground: #07070b;
+  --destructive: #e51300;
+
+  /* Hairlines carry all the structure. */
+  --border: #e4e3de;
+  --input: #e4e3de;
+  --ring: #3e9ca3;
+
+  --surface-3: #ebe9e0;
+  --hairline-strong: #c9c9c4;
+  /* pine-700 — 8.4:1 on the cream canvas. */
+  --verdant: #1c5341;
+
+  /* Mosaic snow tones. Kept separate from the surface palette so the tiles
+     do not follow the canvas when the theme goes dark. Seven steps, not
+     three: the mosaic caps every colour at two tiles per frame, and the
+     `band` variant carries thirteen neutral tiles — three tones could only
+     ever cover six. All stay light enough for near-black glyph ink. */
+  --mosaic-1: #f5f4ef;
+  --mosaic-2: #ebe9e0;
+  --mosaic-3: #e2e0d6;
+  --mosaic-4: #d8d5c9;
+  --mosaic-5: #c9c9c4;
+  --mosaic-6: #bcbcb5;
+  --mosaic-7: #aeaea6;
+
+  --chart-1: #2e7358;
+  --chart-2: #3e9ca3;
+  --chart-3: #7fb69b;
+  --chart-4: #a98363;
+  --chart-5: #7ec6c6;
+
+  --sidebar: #fbfbf8;
+  --sidebar-foreground: #07070b;
+  --sidebar-primary: #07070b;
+  --sidebar-primary-foreground: #fbfbf8;
+  --sidebar-accent: #f5f4ef;
+  --sidebar-accent-foreground: #07070b;
+  --sidebar-border: #e4e3de;
+  --sidebar-ring: #3e9ca3;
 }
 
+/* ── Dark: neutral near-black, same structure ───────────────────────── */
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: #0a0a0c;
+  --foreground: #fbfbf8;
+  --card: #0a0a0c;
+  --card-foreground: #fbfbf8;
+  --popover: #121215;
+  --popover-foreground: #fbfbf8;
+
+  --primary: #fbfbf8;
+  --primary-foreground: #0a0a0c;
+  --secondary: #121215;
+  --secondary-foreground: #fbfbf8;
+  --muted: #121215;
+  --muted-foreground: #9b9ba3;
+  --accent: #1a1a1e;
+  --accent-foreground: #fbfbf8;
+  --destructive: #ff5229;
+
+  --border: #26262b;
+  --input: #26262b;
+  --ring: #7ec6c6;
+
+  --surface-3: #1a1a1e;
+  --hairline-strong: #34343a;
+  /* pine-700 is only 1.7:1 here — step to the light end of the ramp. */
+  --verdant: #7fb69b;
+
+  /* Mosaic tiles stay light in both themes, so the block always reads as
+     snow-and-forest rather than dissolving into the canvas. */
+  --mosaic-1: #fbfbf8;
+  --mosaic-2: #f2f1ec;
+  --mosaic-3: #e9e8e1;
+  --mosaic-4: #dcdbd4;
+  --mosaic-5: #cfcec6;
+  --mosaic-6: #c2c1b8;
+  --mosaic-7: #b4b3aa;
+
+  --sidebar: #08080a;
+  --sidebar-foreground: #fbfbf8;
+  --sidebar-primary: #fbfbf8;
+  --sidebar-primary-foreground: #0a0a0c;
+  --sidebar-accent: #121215;
+  --sidebar-accent-foreground: #fbfbf8;
+  --sidebar-border: #26262b;
+  --sidebar-ring: #7ec6c6;
 }
 
 @layer base {
   * {
     @apply border-border outline-ring/50;
   }
+
+  /* Hide the page scrollbar (scrolling still works) and stop full-bleed
+     mosaics from creating sideways overflow. */
+  html {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  html::-webkit-scrollbar {
+    display: none;
+  }
+  html,
   body {
-    @apply bg-background text-foreground;
+    overflow-x: clip;
+    overscroll-behavior-y: none;
+  }
+
+  body {
+    @apply bg-background text-foreground font-sans;
+    letter-spacing: -0.01em;
+  }
+
+  /* Must be @apply, not `font-family: var(--font-display)` — `@theme
+     inline` inlines its values into the generated utilities instead of
+     emitting :root custom properties, so the raw var() is empty here. */
+  h1,
+  h2,
+  h3,
+  h4 {
+    @apply font-display;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+  }
+
+  ::selection {
+    background-color: #7ec6c6;
+    color: #07070b;
   }
 }
+
+/* ── Ink band ────────────────────────────────────────────────────────
+   Full-bleed dark section. Re-themes its children so shadcn primitives
+   nested inside pick up the right hairline and muted values. Identical
+   in light and dark themes by design. */
+.surface-ink {
+  --background: #0a0a0c;
+  --foreground: #fbfbf8;
+  --card: #0a0a0c;
+  --card-foreground: #fbfbf8;
+  --popover: #121215;
+  --popover-foreground: #fbfbf8;
+  --primary: #fbfbf8;
+  --primary-foreground: #0a0a0c;
+  --secondary: #121215;
+  --secondary-foreground: #fbfbf8;
+  --muted: #121215;
+  --muted-foreground: #9b9ba3;
+  --accent: #1a1a1e;
+  --accent-foreground: #fbfbf8;
+  --border: #26262b;
+  --input: #26262b;
+  --surface-3: #1a1a1e;
+  --hairline-strong: #34343a;
+  --mosaic-1: #fbfbf8;
+  --mosaic-2: #f2f1ec;
+  --mosaic-3: #e9e8e1;
+  --mosaic-4: #dcdbd4;
+  --mosaic-5: #cfcec6;
+  --mosaic-6: #c2c1b8;
+  --mosaic-7: #b4b3aa;
+  background-color: #0a0a0c;
+  color: #fbfbf8;
+}
+
+/* Hairlines inside a ruled grid are drawn by a 1px gap over the
+   container's border colour (see components/mistral/ruled-grid.tsx), so
+   cells need an opaque background to sit on top of it. */
+.ruled-cell {
+  background-color: var(--background);
+}
+
+/* ── Quiet link ──────────────────────────────────────────────────────
+   No underline at rest; the row tints on hover instead. */
+@utility link-quiet {
+  text-decoration-line: none;
+  transition: color 0.2s ease;
+  &:hover {
+    color: var(--foreground);
+  }
+}
+
+/* ── Pixel-arrow row ─────────────────────────────────────────────────
+   List and menu rows slide a pixel arrow in from the left while the
+   label shifts right, over 300ms with a 50ms delay. Used by the
+   mega-menu and every ruled link list. */
+@utility row-arrow {
+  & [data-arrow] {
+    transform: translateX(-2.5rem);
+    transition: transform 0.3s ease 0.05s;
+  }
+  & [data-arrow-label] {
+    transition: transform 0.3s ease 0.05s;
+  }
+  &:hover [data-arrow],
+  &:focus-visible [data-arrow] {
+    transform: translateX(0);
+  }
+  &:hover [data-arrow-label],
+  &:focus-visible [data-arrow-label] {
+    transform: translateX(1.75rem);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    & [data-arrow],
+    & [data-arrow-label] {
+      transition: none;
+    }
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Motion
+   Short distances, few durations, one curve. Reveals move 4px over 200ms;
+   entrances land in 500ms; only ambient loops run longer. Everything is
+   disabled wholesale under prefers-reduced-motion at the end of this file.
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* ── Scroll reveal (JS-gated so no-JS users always see content) ─────── */
+html.js [data-reveal] {
+  opacity: 0;
+  transform: translateY(4px);
+  transition:
+    opacity 0.2s ease-in-out,
+    transform 0.2s ease-in-out;
+  transition-delay: var(--reveal-delay, 0ms);
+}
+html.js [data-reveal][data-revealed="true"] {
+  opacity: 1;
+  transform: none;
+}
+
+/* ── Block entrance ──────────────────────────────────────────────────
+   Tiles fall in and settle: land, squash to 95%, overshoot to 102%, rest.
+   The squash is what stops a grid of falling squares reading as a slide. */
+@keyframes tile-fall {
+  0% {
+    opacity: 0;
+    transform: translateY(-200px);
+  }
+  50% {
+    opacity: 1;
+    transform: translateY(0) scaleY(1);
+  }
+  65% {
+    opacity: 1;
+    transform: translateY(0) scaleY(0.95);
+  }
+  80% {
+    opacity: 1;
+    transform: translateY(0) scaleY(1.02);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scaleY(1);
+  }
+}
+
+/* Rotated tiles scale in instead of falling — a diamond dropping from
+   above reads as debris, where scaling reads as placement. */
+@keyframes tile-scale-in {
+  0% {
+    opacity: 0;
+    transform: scale(0);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* ── Mosaic ambient loop ─────────────────────────────────────────────
+   Every tile is a four-sided prism. It turns a quarter at a time, and
+   each face carries its own colour *and* its own content — so a tile can
+   come back round with a different letter, a different motif, or nothing
+   at all.
+
+   No perspective, and therefore no translateZ on the faces. Under
+   orthographic projection a face rotated ±90° is edge-on and has zero
+   width whatever its depth, so the four faces need no Z offset to sit on
+   a prism. That removes the container-query units this would otherwise
+   need to know half a tile's width, and it guarantees the turn can never
+   overshoot its cell — which matters, because tiles butt together with
+   no gap.
+
+   This replaces a `background-color` keyframe. That animated a paint
+   property on every tile; this animates a transform on one element per
+   tile. Same count, compositor instead of paint. */
+/* A tile holds each face for almost a quarter of the loop and turns for
+   about 3% of it. That is what keeps the mosaic still: with the tiles'
+   start offsets spread evenly across a quarter-loop, turns fire one at a
+   time and only 4 x tiles x 0.03 of them overlap — about three or four in
+   the hero at any moment, the rest motionless.
+
+   Two axes and two directions, chosen per tile from the seed, so a turn
+   can go left, right, up or down. */
+@keyframes tile-turn-y {
+  0%,
+  22% {
+    transform: rotateY(0deg);
+  }
+  25%,
+  47% {
+    transform: rotateY(-90deg);
+  }
+  50%,
+  72% {
+    transform: rotateY(-180deg);
+  }
+  75%,
+  97% {
+    transform: rotateY(-270deg);
+  }
+  100% {
+    transform: rotateY(-360deg);
+  }
+}
+
+@keyframes tile-turn-x {
+  0%,
+  22% {
+    transform: rotateX(0deg);
+  }
+  25%,
+  47% {
+    transform: rotateX(-90deg);
+  }
+  50%,
+  72% {
+    transform: rotateX(-180deg);
+  }
+  75%,
+  97% {
+    transform: rotateX(-270deg);
+  }
+  100% {
+    transform: rotateX(-360deg);
+  }
+}
+
+/* Size containment so a face can address the tile's own width in `cqw`,
+   which is how it finds the half-tile depth it has to sit at. Safe here:
+   the tile is sized by the grid and `aspect-square`, never by what is
+   inside it. The containment is on the tile rather than on the cube, so
+   it cannot flatten the cube's 3D context. */
+.mosaic-tile {
+  container-type: size;
+}
+
+.mosaic-cube {
+  position: absolute;
+  inset: 0;
+  transform-style: preserve-3d;
+}
+
+.mosaic-face {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  /* The face 180° away is turned away from the viewer; without this you
+     see it mirrored through the one in front. */
+  backface-visibility: hidden;
+}
+
+@keyframes mosaic-diamond {
+  0% {
+    rotate: 45deg;
+  }
+  50% {
+    rotate: 135deg;
+  }
+  100% {
+    rotate: 45deg;
+  }
+}
+
+/* Default mosaic: tiles fall in, and the prism turns.
+   `tile-fall` is the reference's block-entrance, scoped in their stylesheet
+   to the bento and markitecture sections — NOT the hero. It is correct for
+   the archive grid and wrong for the hero band, which is why the hero opts
+   out below. */
+[data-mosaic][data-revealed="true"] .mosaic-tile {
+  animation: tile-fall 0.5s ease-in backwards;
+  animation-delay: calc(var(--i, 0) * 30ms);
+}
+
+[data-mosaic][data-revealed="true"] .mosaic-tile[data-kind="diamond"] {
+  animation-name: tile-scale-in;
+}
+
+/* Hero mosaic: no entrance on the tiles at all. The reference fades the
+   whole container in and the tile motion is a continuous loop. */
+[data-mosaic="hero"][data-revealed="true"] .mosaic-tile,
+[data-mosaic="hero"][data-revealed="true"] .mosaic-tile[data-kind="diamond"] {
+  animation: none;
+}
+
+/* `--turn-slot` is the tile's position in a shuffled, evenly spaced queue,
+   as a fraction of one quarter-loop — a tile's own turns are a quarter
+   apart, so spreading offsets over a quarter covers the whole cycle
+   uniformly. The delay is negative, so every tile is already somewhere in
+   its cycle on the first frame rather than all starting together.
+
+   The easing applies per segment. Between two keyframes holding the same
+   angle it does nothing; across a turn it gives the ease-in-out. */
+[data-mosaic][data-revealed="true"] .mosaic-cube {
+  animation: tile-turn-y var(--mosaic-loop, 48s) ease-in-out infinite;
+  animation-delay: calc(var(--mosaic-loop, 48s) / -4 * var(--turn-slot, 0));
+}
+
+[data-mosaic][data-revealed="true"] .mosaic-cube[data-axis="x"] {
+  animation-name: tile-turn-x;
+}
+
+[data-mosaic][data-revealed="true"] .mosaic-cube[data-dir="reverse"] {
+  animation-direction: reverse;
+}
+
+[data-mosaic][data-revealed="true"] .mosaic-diamond {
+  animation: mosaic-diamond var(--mosaic-loop, 48s) ease-in-out infinite;
+}
+
+/* Stop the loop once a mosaic leaves the viewport. A CSS animation runs
+   whether or not anything can see it, so without this every mosaic on the
+   page is turning from the moment it loads and the page never goes idle.
+
+   The attribute is written straight to the node by an IntersectionObserver
+   rather than through React state, so scrolling past a mosaic costs no
+   re-render. Absent attribute means running, so a browser without
+   IntersectionObserver — or markup before hydration — behaves as before. */
+[data-mosaic][data-in-view="false"] .mosaic-tile,
+[data-mosaic][data-in-view="false"] .mosaic-cube,
+[data-mosaic][data-in-view="false"] .mosaic-diamond {
+  animation-play-state: paused;
+}
+
+/* ── Headline character rise ─────────────────────────────────────────
+   Characters slide up from behind a per-line mask, rather than fading.
+   The reference splits the title into lines/words/chars, clips each line,
+   and tweens every character from y:100% to 0 on a stagger that grows
+   with character index and carries a random multiplier — so the line
+   resolves left to right but unevenly, never as a mechanical sweep.
+
+   Delays are seeded, not random, so SSR and the client agree. */
+@keyframes char-rise {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+/* The mask. Nothing outside the line box is ever visible, which is what
+   makes characters appear to emerge from the baseline rather than fly in. */
+.hero-line {
+  display: block;
+  overflow: hidden;
+  /* Descenders need headroom or the mask clips them; the reference uses
+     the same 1.15 factor on its measured line height. */
+  padding-bottom: 0.15em;
+  margin-bottom: -0.15em;
+}
+
+.hero-char {
+  display: inline-block;
+  white-space: pre;
+  animation: char-rise 0.5s cubic-bezier(0.22, 0.61, 0.36, 1) backwards;
+  animation-delay: var(--char-delay, 0ms);
+}
+
+/* `grow`: the line box itself opens from nothing, so the block builds
+   downward while the characters rise inside it. */
+@keyframes line-grow {
+  from {
+    max-height: 0;
+  }
+  to {
+    max-height: 1.3em;
+  }
+}
+
+.hero-line-grow {
+  animation: line-grow 0.5s ease-in-out backwards;
+  animation-delay: var(--line-delay, 0ms);
+}
+
+/* The hero used to pin its first screen with a `.hero-pin` sticky rule
+   while a second screen scrolled over it. The hero is now a scrubbed GSAP
+   timeline that owns its own sticky container, so that rule is gone. */
+
+/* ── Menu unroll ─────────────────────────────────────────────────────
+   Panels unroll downward rather than fading in place. */
+@keyframes unroll-in {
+  0% {
+    opacity: 0;
+    max-height: 0;
+  }
+  30% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 1;
+    max-height: 40rem;
+  }
+}
+
+.animate-unroll-in {
+  animation: unroll-in 0.5s forwards ease-in-out;
+  overflow: hidden;
+}
+
+/* ── Small-element entrance ──────────────────────────────────────────
+   The only overshoot in the system, reserved for chips and badges. */
+@keyframes pop-in {
+  0% {
+    transform: scale(0);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.animate-pop-in {
+  animation: pop-in 0.3s forwards ease-in-out;
+}
+
+/* ── Scroll cue ──────────────────────────────────────────────────────
+   Three stacked chevrons pulsing in sequence. */
+@keyframes arrow-cue {
+  0%,
+  40% {
+    opacity: 0.2;
+  }
+  50% {
+    opacity: 1;
+  }
+  60%,
+  100% {
+    opacity: 0.2;
+  }
+}
+
+.animate-arrow-cue {
+  animation: arrow-cue 2s linear infinite;
+}
+
+/* ── Marquee ─────────────────────────────────────────────────────────
+   The track holds the sequence twice and moves exactly -50%, so the wrap
+   is seamless. */
+@keyframes marquee-scroll {
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.marquee-track {
+  animation: marquee-scroll var(--marquee-duration, 40s) linear infinite;
+}
+
+.marquee:hover .marquee-track {
+  animation-play-state: paused;
+}
+
 @keyframes fade-slide {
   from {
     opacity: 0;
-    transform: translateY(10px);
+    transform: translateY(4px);
   }
   to {
     opacity: 1;
@@ -135,28 +758,60 @@
 }
 
 .animate-fade-slide {
-  animation: fade-slide 0.4s ease-out forwards;
+  animation: fade-slide 0.2s ease-in-out forwards;
 }
 
-@import "tailwindcss";
-@import "tw-animate-css";
-
-@utility glass {
-  background-color: oklch(from var(--background) l c h / 40%);
-  backdrop-filter: blur(12px) saturate(150%);
-  -webkit-backdrop-filter: blur(12px) saturate(150%);
-  border: 1px solid var(--border);
+/* Mosaic entering the hero: a plain fade, held back just long enough for
+   the headline's first words to land first. */
+.hero-fade-in {
+  animation: fade-in 0.6s 0.3s ease-in-out both;
 }
 
-@layer base {
-  * {
-    @apply border-border outline-ring/50;
+@keyframes fade-in {
+  from {
+    opacity: 0;
   }
-  body {
-    @apply bg-background text-foreground;
+  to {
+    opacity: 1;
   }
 }
 
-@utility text-brand {
-  @apply bg-linear-to-r from-emerald-700 via-green-700 to-amber-600 bg-clip-text text-transparent;
+/* ── Reduced motion ──────────────────────────────────────────────────
+   Everything above resolves to its end state. Ambient loops stop rather
+   than freezing mid-phase, which would leave tiles on an arbitrary
+   colour; `animation: none` returns them to their painted fill. */
+@media (prefers-reduced-motion: reduce) {
+  [data-reveal] {
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+  [data-mosaic] .mosaic-tile,
+  [data-mosaic] .mosaic-cube,
+  [data-mosaic] .mosaic-diamond,
+  .animate-unroll-in,
+  .animate-pop-in,
+  .animate-arrow-cue,
+  .animate-fade-slide,
+  .marquee-track,
+  .hero-char,
+  .hero-line-grow,
+  .hero-fade-in {
+    animation: none !important;
+  }
+  /* The marquee is the one loop that leaves content off-screen when it
+     stops, because the track is translated. Reset it so the first copy
+     of the list is the one showing. */
+  .marquee-track {
+    transform: none !important;
+  }
+  /* The mask exists only to hide characters mid-rise; with no rise it
+     would still clip descenders, so it is released too. */
+  .hero-line {
+    overflow: visible;
+  }
+  .animate-unroll-in {
+    max-height: none;
+    opacity: 1;
+  }
 }

--- a/himvirasat-frontend/app/icon.tsx
+++ b/himvirasat-frontend/app/icon.tsx
@@ -1,0 +1,51 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 64, height: 64 };
+export const contentType = "image/png";
+
+/** Same snow-capped ridgeline as components/mistral/logo-mark.tsx. */
+const TILES: Array<[number, number, number]> = [
+  [2, 0, 0],
+  [1, 1, 1],
+  [2, 1, 1],
+  [0, 2, 2],
+  [1, 2, 2],
+  [2, 2, 2],
+  [3, 2, 3],
+  [0, 3, 4],
+  [1, 3, 4],
+  [2, 3, 3],
+  [3, 3, 4],
+];
+
+/** summit → base: glacier, sage, forest, pine, timber. */
+const PEAK = ["#7ec6c6", "#7fb69b", "#2e7358", "#1c5341", "#6e4e36"];
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          background: "#fbfbf8",
+        }}
+      >
+        <svg width="64" height="64" viewBox="0 0 32 32">
+          {TILES.map(([col, row, step]) => (
+            <rect
+              key={`${col}-${row}`}
+              x={col * 8}
+              y={row * 8}
+              width={8}
+              height={8}
+              fill={PEAK[step]}
+            />
+          ))}
+        </svg>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/himvirasat-frontend/app/layout.tsx
+++ b/himvirasat-frontend/app/layout.tsx
@@ -1,6 +1,50 @@
 import "./globals.css";
 
+import type { Metadata, Viewport } from "next";
+
+import { fontVariables } from "@/lib/fonts";
+import { site } from "@/lib/site";
+
 import { Providers } from "./providers";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(site.url),
+  title: {
+    default: `${site.name} · ${site.tagline}`,
+    template: `%s · ${site.name}`,
+  },
+  description: site.description,
+  keywords: [
+    "Himachal Pradesh",
+    "Himachali languages",
+    "Pahari",
+    "Mandeali",
+    "Kangri",
+    "Takri script",
+    "Devanagari",
+    "open dataset",
+    "language preservation",
+  ],
+  openGraph: {
+    siteName: site.name,
+    type: "website",
+    locale: "en_IN",
+    title: `${site.name} · ${site.tagline}`,
+    description: site.description,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${site.name} · ${site.tagline}`,
+    description: site.description,
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#fbfbf8" },
+    { media: "(prefers-color-scheme: dark)", color: "#0a0a0c" },
+  ],
+};
 
 export default function RootLayout({
   children,
@@ -9,7 +53,17 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body suppressHydrationWarning className="antialiased">
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `document.documentElement.classList.add("js")`,
+          }}
+        />
+      </head>
+      <body
+        suppressHydrationWarning
+        className={`${fontVariables} antialiased`}
+      >
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/himvirasat-frontend/app/not-found.tsx
+++ b/himvirasat-frontend/app/not-found.tsx
@@ -1,36 +1,32 @@
 import Link from "next/link";
+
+import { Eyebrow } from "@/components/mistral/eyebrow";
+import { TakriMosaic } from "@/components/mistral/takri-mosaic";
 import { Button } from "@/components/ui/button";
 
 export default function NotFound() {
   return (
-    <div className="relative min-h-screen flex items-center justify-center overflow-hidden">
-      <div
-        className="absolute inset-0 bg-cover bg-center"
-        style={{ backgroundImage: "url('/mountains1.png')" }}
-      />
-      <div className="absolute inset-0 bg-white/40 dark:bg-black/70 backdrop-blur-[2px]" />
-
-      <main className="relative z-10 text-center px-6">
-        <span className="text-emerald-600 dark:text-emerald-400 font-bold tracking-widest uppercase text-sm">
+    <div className="flex min-h-svh flex-col">
+      <main className="mx-auto flex w-full max-w-prose flex-1 flex-col justify-center px-6 py-24 text-center">
+        <Eyebrow size="lg" className="justify-center">
           Error 404
-        </span>
-        <h1 className="mt-4 text-6xl md:text-8xl font-bold text-slate-900 dark:text-white tracking-tighter">
-          Lost in the <br /> Clouds?
+        </Eyebrow>
+        <h1 className="text-display-md md:text-display-xl mt-6 text-balance">
+          This trail does not exist.
         </h1>
-        <p className="mt-6 text-lg text-slate-700 dark:text-slate-300 max-w-md mx-auto leading-relaxed">
-          {`The trail you're looking for doesn't exist.`} It might have been
-          moved or renamed in our heritage archives.
+        <p className="text-body-lg text-muted-foreground mx-auto mt-6 max-w-md">
+          The page you are looking for may have been moved or renamed.
         </p>
-
-        <div className="mt-10">
-          <Button
-            asChild
-            className="h-14 px-8 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white border-none shadow-xl transition-all hover:scale-105"
-          >
-            <Link href="/">Return to Basecamp</Link>
+        <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
+          <Button asChild size="lg">
+            <Link href="/">Back to the homepage</Link>
+          </Button>
+          <Button asChild size="lg" variant="secondary">
+            <Link href="/vocabulary">Search the vocabulary</Link>
           </Button>
         </div>
       </main>
+      <TakriMosaic variant="band" seed={404} />
     </div>
   );
 }

--- a/himvirasat-frontend/app/opengraph-image.tsx
+++ b/himvirasat-frontend/app/opengraph-image.tsx
@@ -1,0 +1,213 @@
+import { ImageResponse } from "next/og";
+
+import { site } from "@/lib/site";
+
+export const alt = "HimVirasat · Open language preservation for Himachal";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const CANVAS = "#fbfbf8";
+const INK = "#07070b";
+const MUTED = "#5a5a63";
+const HAIRLINE = "#e4e3de";
+/** summit → base: glacier, sage, forest, pine, timber. */
+const PEAK = ["#7ec6c6", "#7fb69b", "#2e7358", "#1c5341", "#6e4e36"];
+
+/** The wider Deodar ramp, used for the tile band. */
+const DEODAR = [
+  "#7fb69b",
+  "#4e9578",
+  "#2e7358",
+  "#1c5341",
+  "#0f3a2e",
+  "#7ec6c6",
+  "#3e9ca3",
+  "#a98363",
+  "#6e4e36",
+];
+
+/** Snow-capped ridgeline, matching components/mistral/logo-mark.tsx. */
+const MARK_TILES: Array<[number, number, number]> = [
+  [2, 0, 0],
+  [1, 1, 1],
+  [2, 1, 1],
+  [0, 2, 2],
+  [1, 2, 2],
+  [2, 2, 2],
+  [3, 2, 3],
+  [0, 3, 4],
+  [1, 3, 4],
+  [2, 3, 3],
+  [3, 3, 4],
+];
+
+/* Deterministic tile band along the bottom edge. */
+const BAND = Array.from({ length: 20 }, (_, i) => DEODAR[(i * 7 + 3) % 9]);
+
+async function loadGoogleFont(family: string): Promise<ArrayBuffer> {
+  const css = await fetch(`https://fonts.googleapis.com/css2?family=${family}`, {
+    headers: { "User-Agent": "Mozilla/5.0" },
+  }).then((res) => res.text());
+  const match = css.match(/url\((https:[^)]+\.(?:ttf|woff))\)/);
+  if (!match) throw new Error("No usable font URL in Google Fonts CSS");
+  const font = await fetch(match[1]);
+  if (!font.ok) throw new Error("Font download failed");
+  return font.arrayBuffer();
+}
+
+function composition(withDevanagari: boolean) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        position: "relative",
+        padding: "0 96px",
+        backgroundColor: CANVAS,
+        fontFamily: withDevanagari ? "Geist" : "sans-serif",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 22,
+            letterSpacing: 3,
+            color: MUTED,
+          }}
+        >
+          OPEN LANGUAGE PRESERVATION
+        </div>
+
+        {withDevanagari ? (
+          <div
+            style={{
+              display: "flex",
+              fontFamily: "Noto Serif Devanagari",
+              fontSize: 104,
+              lineHeight: 1.2,
+              marginTop: 24,
+              color: INK,
+            }}
+          >
+            {site.nativeName}
+          </div>
+        ) : null}
+
+        <div
+          style={{
+            display: "flex",
+            fontSize: 52,
+            marginTop: withDevanagari ? 8 : 36,
+            color: INK,
+          }}
+        >
+          {site.name}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            fontSize: 30,
+            marginTop: 20,
+            color: MUTED,
+          }}
+        >
+          Open language preservation for Himachal
+        </div>
+      </div>
+
+      {/* Mosaic mark */}
+      <div
+        style={{
+          display: "flex",
+          width: 264,
+          height: 264,
+          position: "relative",
+        }}
+      >
+        {MARK_TILES.map(([col, row, step]) => (
+          <div
+            key={`${col}-${row}`}
+            style={{
+              position: "absolute",
+              left: col * 66,
+              top: row * 66,
+              width: 66,
+              height: 66,
+              backgroundColor: PEAK[step],
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Hairline above the tile band */}
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: 48,
+          height: 1,
+          backgroundColor: HAIRLINE,
+          display: "flex",
+        }}
+      />
+
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: 48,
+          display: "flex",
+        }}
+      >
+        {BAND.map((fill, i) => (
+          <div
+            key={i}
+            style={{ width: 60, height: 48, backgroundColor: fill }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default async function OpengraphImage() {
+  try {
+    const [deva, display, takri] = await Promise.all([
+      loadGoogleFont("Noto+Serif+Devanagari:wght@600&subset=devanagari"),
+      loadGoogleFont("Geist:wght@500"),
+      // css2 subset param is unreliable for Takri; the default TTF covers it.
+      loadGoogleFont("Noto+Sans+Takri:wght@400"),
+    ]);
+    return new ImageResponse(composition(true), {
+      ...size,
+      fonts: [
+        {
+          name: "Noto Serif Devanagari",
+          data: deva,
+          style: "normal",
+          weight: 600,
+        },
+        { name: "Geist", data: display, style: "normal", weight: 500 },
+        { name: "Noto Sans Takri", data: takri, style: "normal", weight: 400 },
+      ],
+    });
+  } catch {
+    // Font fetch failed — satori cannot shape Devanagari without a loaded
+    // font, so fall back to a Latin-only composition with system fonts.
+    return new ImageResponse(composition(false), size);
+  }
+}

--- a/himvirasat-frontend/app/robots.ts
+++ b/himvirasat-frontend/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+import { site } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/admin"],
+    },
+    sitemap: new URL("/sitemap.xml", site.url).toString(),
+  };
+}

--- a/himvirasat-frontend/app/sitemap.ts
+++ b/himvirasat-frontend/app/sitemap.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+
+import { site } from "@/lib/site";
+import { dialectsConfig } from "@/lib/dialects/dialect-config";
+
+const staticRoutes = [
+  "/",
+  "/about",
+  "/contribute",
+  "/datasets",
+  "/tools",
+  "/tools/transliterator",
+  "/vocabulary",
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const routes = [
+    ...staticRoutes,
+    ...dialectsConfig.map((dialect) => `/vocabulary/${dialect.id}`),
+  ];
+
+  return routes.map((path) => ({
+    url: new URL(path, site.url).toString(),
+  }));
+}

--- a/himvirasat-frontend/components/about/team-section.tsx
+++ b/himvirasat-frontend/components/about/team-section.tsx
@@ -1,19 +1,21 @@
 "use client";
 
 import type { ElementType } from "react";
-import { Crown, Code2, Languages, Mail } from "lucide-react";
 import {
-  FaGithub,
   FaDiscord,
-  FaRedditAlien,
-  FaXTwitter,
+  FaEnvelope,
+  FaGithub,
   FaInstagram,
   FaLinkedin,
+  FaRedditAlien,
+  FaXTwitter,
 } from "react-icons/fa6";
 
+import { Eyebrow } from "@/components/mistral/eyebrow";
+import { RuledGrid } from "@/components/mistral/ruled-grid";
+import { SectionHeading } from "@/components/mistral/section-heading";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
+import { site } from "@/lib/site";
 import { cn } from "@/lib/utils";
 
 function initials(name: string) {
@@ -29,7 +31,7 @@ function SocialRow({ socials }: { socials?: SocialLink[] }) {
   if (!socials?.length) return null;
 
   return (
-    <div className="flex flex-wrap items-center justify-center gap-2">
+    <div className="flex flex-wrap items-center gap-1.5">
       {socials.map((social) => {
         const Icon = SOCIAL_ICONS[social.platform];
 
@@ -40,12 +42,9 @@ function SocialRow({ socials }: { socials?: SocialLink[] }) {
             target="_blank"
             rel="noopener noreferrer"
             aria-label={`${social.platform} profile`}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full border 
-            border-emerald-500/15 bg-emerald-500/5 text-slate-600 
-            transition-colors hover:bg-emerald-500/10 hover:text-emerald-700 
-            dark:text-zinc-300 dark:hover:text-emerald-400"
+            className="border-border text-muted-foreground hover:bg-secondary hover:text-foreground inline-flex size-8 items-center justify-center rounded-md border transition-colors"
           >
-            <Icon className="h-4 w-4" />
+            <Icon className="size-3.5" />
           </a>
         );
       })}
@@ -53,193 +52,144 @@ function SocialRow({ socials }: { socials?: SocialLink[] }) {
   );
 }
 
-function PersonCard({
-  member,
-  size = "md",
-}: {
-  member: TeamMember;
-  size?: "lg" | "md" | "sm";
-}) {
-  const cardPadding = size === "lg" ? "p-6" : size === "md" ? "p-5" : "p-4";
-  const avatarSize =
-    size === "lg" ? "h-20 w-20" : size === "md" ? "h-16 w-16" : "h-14 w-14";
-  const nameSize =
-    size === "lg" ? "text-lg" : size === "md" ? "text-base" : "text-sm";
-  const roleSize = size === "lg" ? "text-md" : "text-[12px]";
-
+function PersonCard({ member }: { member: TeamMember }) {
   return (
-    <Card className="h-full border-white/20 bg-white/45 dark:bg-white/5">
-      <CardContent
-        className={cn(cardPadding, "flex flex-col items-center text-center")}
-      >
-        <Avatar className={cn(avatarSize, "ring-2 ring-emerald-500/25")}>
-          <AvatarImage src={member.avatar} alt={member.name} />
-          <AvatarFallback className="bg-emerald-600/10 text-emerald-700 dark:text-emerald-400">
-            {initials(member.name)}
-          </AvatarFallback>
-        </Avatar>
+    <div className="ruled-cell flex flex-col p-8">
+      <Avatar className="border-border size-16 border">
+        <AvatarImage src={member.avatar} alt={member.name} />
+        <AvatarFallback className="bg-pine-100 text-[#07070b]">
+          {initials(member.name)}
+        </AvatarFallback>
+      </Avatar>
 
-        <h3
-          className={cn(
-            "mt-3 font-semibold text-slate-900 dark:text-white",
-            nameSize
-          )}
-        >
-          {member.name}
-        </h3>
+      <h3 className="text-title mt-5">{member.name}</h3>
+      <Eyebrow className="mt-2">{member.role}</Eyebrow>
 
-        <p
-          className={cn(
-            "mt-1 uppercase tracking-wide text-emerald-700 dark:text-emerald-400 font-semibold",
-            roleSize
-          )}
-        >
-          {member.role}
-        </p>
+      {member.languages?.length ? (
+        <div className="mt-4 flex flex-wrap gap-1.5">
+          {member.languages.map((language) => (
+            <span
+              key={language}
+              className="animate-pop-in border-border text-body-sm text-muted-foreground rounded-md border px-2.5 py-0.5"
+            >
+              {language}
+            </span>
+          ))}
+        </div>
+      ) : null}
 
-        {member.languages?.length ? (
-          <div className="mt-4 flex flex-wrap justify-center gap-2">
-            {member.languages.map((language) => (
-              <Badge
-                key={language}
-                variant="secondary"
-                className="bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-              >
-                {language}
-              </Badge>
-            ))}
-          </div>
-        ) : null}
-
-        {member.socials?.length ? (
-          <div className="mt-4">
-            <SocialRow socials={member.socials} />
-          </div>
-        ) : null}
-      </CardContent>
-    </Card>
-  );
-}
-
-function ConnectorLine() {
-  return (
-    <div className="flex justify-center" aria-hidden="true">
-      <div className="my-8 h-20 w-px bg-linear-to-b from-emerald-500/80 to-emerald-500/80" />
+      {member.socials?.length ? (
+        <div className="mt-6">
+          <SocialRow socials={member.socials} />
+        </div>
+      ) : null}
     </div>
   );
 }
 
-function SectionShell({
-  icon: Icon,
+function OpenSlot() {
+  return (
+    <div className="border-border border border-dashed p-8 text-center">
+      <p className="text-title text-muted-foreground">Your name here</p>
+      <p className="text-body-sm text-muted-foreground mt-2">
+        <a
+          href={site.links.discordHimvirasat}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="link-quiet underline underline-offset-4"
+        >
+          Join the Discord and start contributing.
+        </a>
+      </p>
+    </div>
+  );
+}
+
+function TeamBranch({
+  eyebrow,
   title,
   subtitle,
-  children,
+  leads,
+  membersHeading,
+  membersSubtitle,
+  members,
+  className,
 }: {
-  icon: ElementType;
+  eyebrow: string;
   title: string;
   subtitle: string;
-  children: React.ReactNode;
+  leads: TeamMember[];
+  membersHeading: string;
+  membersSubtitle: string;
+  members: TeamMember[];
+  className?: string;
 }) {
   return (
-    <Card className="border-white/20 bg-white/40 backdrop-blur-none dark:bg-white/5">
-      <CardContent className="p-6 sm:p-8">
-        <div className="mb-10 flex flex-col items-center text-center">
-          <div className="flex items-center gap-2">
-            <Icon className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-            <h3 className="text-2xl font-bold text-slate-900 dark:text-white">
-              {title}
-            </h3>
-          </div>
-          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-slate-700 dark:text-zinc-400">
-            {subtitle}
-          </p>
-        </div>
+    <section className={cn("border-border border-t pt-16", className)}>
+      <Eyebrow size="lg">{eyebrow}</Eyebrow>
+      <h3 className="text-display-md mt-4 text-balance">{title}</h3>
+      <p className="text-body text-muted-foreground mt-4 max-w-2xl">
+        {subtitle}
+      </p>
 
-        {children}
-      </CardContent>
-    </Card>
+      <RuledGrid cols={2} className="mt-10">
+        {leads.map((member) => (
+          <PersonCard key={member.name} member={member} />
+        ))}
+      </RuledGrid>
+
+      <div className="mt-14">
+        <h4 className="text-title">{membersHeading}</h4>
+        <p className="text-body-sm text-muted-foreground mt-2 max-w-2xl">
+          {membersSubtitle}
+        </p>
+
+        {members.length > 0 ? (
+          <RuledGrid cols="2-3" className="mt-8">
+            {members.map((member) => (
+              <PersonCard key={member.name} member={member} />
+            ))}
+          </RuledGrid>
+        ) : (
+          <div className="mt-8">
+            <OpenSlot />
+          </div>
+        )}
+      </div>
+    </section>
   );
 }
 
 export function TeamSection() {
   return (
-    <section className="mt-32 scroll-mt-24">
-      <div className="mb-16 text-center">
-        <span className="flex items-center justify-center gap-2 text-xs font-bold uppercase tracking-widest text-emerald-600 dark:text-emerald-400">
-          <Crown className="h-3.5 w-3.5" />
-          Our Team
-        </span>
+    <section className="scroll-mt-24 py-24 md:py-32">
+      <SectionHeading
+        eyebrow="Our team"
+        title="The people behind HimVirasat."
+        description="A growing community of developers, researchers, language experts, and contributors working together to preserve Himachal's linguistic heritage."
+      />
 
-        <h2 className="mt-4 text-3xl font-bold tracking-tight text-slate-900 dark:text-white md:text-4xl">
-          The People Behind HimVirasat
-        </h2>
+      <div className="mt-20 flex flex-col gap-20">
+        <TeamBranch
+          eyebrow="Technical team"
+          title="Building the platform."
+          subtitle="The technical branch develops HimVirasat's platform, infrastructure, and the systems that power dataset generation, validation, and public releases."
+          leads={TECH_LEADS}
+          membersHeading="Developers"
+          membersSubtitle="Developers and researchers building the technical foundation of HimVirasat."
+          members={DEVELOPERS}
+          className="border-t-0 pt-0"
+        />
 
-        <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-slate-700 dark:text-zinc-400">
-          A growing community of developers, researchers, language experts, and
-          contributors working together to preserve Himachal&apos;s linguistic
-          heritage.
-        </p>
-      </div>
-
-      <div className="space-y-12">
-        <SectionShell
-          icon={Code2}
-          title="Technical Team"
-          subtitle="The technical branch is responsible for developing HimVirasat's platform, infrastructure, 
-          and the systems that power dataset generation, validation, and public releases."
-        >
-          <div className="mx-auto grid max-w-2xl gap-6 md:grid-cols-2">
-            {TECH_LEADS.map((member) => (
-              <PersonCard key={member.name} member={member} size="md" />
-            ))}
-          </div>
-
-          <ConnectorLine />
-          <div className="text-center">
-            <h4 className="text-lg font-semibold text-slate-900 dark:text-white">
-              Developers
-            </h4>
-            <p className="mt-1 text-sm text-slate-600 dark:text-zinc-400">
-              Developers and researchers building the technical foundation of
-              HimVirasat.
-            </p>
-          </div>
-
-          <div className="mt-6 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-            {DEVELOPERS.map((member) => (
-              <PersonCard key={member.name} member={member} size="md" />
-            ))}
-          </div>
-        </SectionShell>
-
-        <SectionShell
-          icon={Languages}
-          title="Language Team"
-          subtitle="The language branch is organized around heads and contributors, keeping each dialect or language stream active and easy to grow."
-        >
-          <div className="mx-auto grid max-w-2xl gap-6 md:grid-cols-2">
-            {LANGUAGE_HEADS.map((member) => (
-              <PersonCard key={member.name} member={member} size="md" />
-            ))}
-          </div>
-
-          <ConnectorLine />
-
-          <div className="text-center">
-            <h4 className="text-lg font-semibold text-slate-900 dark:text-white">
-              Contributors
-            </h4>
-            <p className="mt-1 text-sm text-slate-600 dark:text-zinc-400">
-              Contributors helping preserve and document Himachali languages.
-            </p>
-          </div>
-
-          <div className="mt-6 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-            {CONTRIBUTORS.map((member) => (
-              <PersonCard key={member.name} member={member} size="md" />
-            ))}
-          </div>
-        </SectionShell>
+        <TeamBranch
+          eyebrow="Language team"
+          title="Keeping each dialect active."
+          subtitle="The language branch is organised around heads and contributors, keeping each dialect or language stream active and easy to grow."
+          leads={LANGUAGE_HEADS}
+          membersHeading="Contributors"
+          membersSubtitle="Contributors helping preserve and document Himachali languages."
+          members={CONTRIBUTORS}
+        />
       </div>
     </section>
   );
@@ -355,5 +305,5 @@ const SOCIAL_ICONS: Record<SocialPlatform, ElementType> = {
   twitter: FaXTwitter,
   instagram: FaInstagram,
   linkedin: FaLinkedin,
-  email: Mail,
+  email: FaEnvelope,
 };

--- a/himvirasat-frontend/components/dialects/DialectCard.tsx
+++ b/himvirasat-frontend/components/dialects/DialectCard.tsx
@@ -1,30 +1,65 @@
 import Link from "next/link";
 
+import { Eyebrow } from "@/components/mistral/eyebrow";
+import { PixelIcon } from "@/components/mistral/pixel-icon";
+import { Button } from "@/components/ui/button";
+
 type DialectCardProps = {
   name: string;
   formUrl: string;
 };
 
-export default function DialectCard({ name, formUrl }: DialectCardProps) {
-  return (
-    <div className="rounded-2xl bg-white/90 p-6 shadow dark:bg-zinc-900/80">
-      <h3 className="text-lg font-semibold text-emerald-700 dark:text-emerald-400">
-        {name}
-      </h3>
+/** Dialect → district, only where the mapping is unambiguous. */
+const DISTRICT_MAP: Array<[pattern: string, district: string]> = [
+  ["kangri", "Kangra"],
+  ["mandeali", "Mandi"],
+  ["mandyali", "Mandi"],
+  ["kullvi", "Kullu"],
+  ["kulluvi", "Kullu"],
+  ["kinnauri", "Kinnaur"],
+  ["sirmauri", "Sirmaur"],
+  ["chambeali", "Chamba"],
+  ["chameali", "Chamba"],
+  ["mahasuvi", "Shimla hills"],
+];
 
-      <p className="mt-2 text-sm leading-6 text-zinc-700 dark:text-zinc-300">
+export default function DialectCard({ name, formUrl }: DialectCardProps) {
+  const lowerName = name.toLowerCase();
+  const district = DISTRICT_MAP.find(([pattern]) =>
+    lowerName.includes(pattern),
+  )?.[1];
+  const hasVocabulary = lowerName.includes("mandeali");
+
+  return (
+    <article className="ruled-cell flex h-full flex-col p-8">
+      <h3 className="text-title">{name}</h3>
+      {district && <Eyebrow className="mt-2">{district}</Eyebrow>}
+
+      <p className="text-body-sm text-muted-foreground mt-4">
         Contribute everyday sentences and Hindi translations in the {name}{" "}
         dialect.
       </p>
 
-      <Link
-        href={formUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="mt-4 inline-block rounded-full bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700"
-      >
-        Contribute to {name}
-      </Link>
-    </div>
+      {hasVocabulary && (
+        <p className="mt-4">
+          <Link
+            href="/vocabulary/mandeali"
+            className="text-verdant text-body-sm link-quiet inline-flex items-center gap-1"
+          >
+            Vocabulary live
+            <PixelIcon name="chevron-right" className="size-3.5" />
+          </Link>
+        </p>
+      )}
+
+      <div className="mt-auto pt-8">
+        <Button asChild variant="secondary" className="w-full">
+          <Link href={formUrl} target="_blank" rel="noopener noreferrer">
+            Open the {name} form
+            <PixelIcon name="arrow-up-right" className="size-4" />
+          </Link>
+        </Button>
+      </div>
+    </article>
   );
 }

--- a/himvirasat-frontend/components/layout/Footer.tsx
+++ b/himvirasat-frontend/components/layout/Footer.tsx
@@ -1,61 +1,107 @@
 import Link from "next/link";
-import Image from "next/image";
+
+import { Eyebrow } from "@/components/mistral/eyebrow";
+import { LogoMark } from "@/components/mistral/logo-mark";
+import { RuledCell, RuledGrid } from "@/components/mistral/ruled-grid";
+import { site } from "@/lib/site";
+
+const columns = [
+  {
+    heading: "Explore",
+    links: [
+      { label: "Vocabulary", href: "/vocabulary" },
+      { label: "Datasets", href: "/datasets" },
+    ],
+  },
+  {
+    heading: "Tools",
+    links: [
+      { label: "Transliterator", href: "/tools/transliterator" },
+      { label: "All tools", href: "/tools" },
+      { label: "Contribute", href: "/contribute" },
+    ],
+  },
+  {
+    heading: "Community",
+    links: [
+      { label: "HimVirasat Discord", href: site.links.discordHimvirasat },
+      { label: "HP Community Discord", href: site.links.discordHpCommunity },
+      { label: "GitHub", href: site.links.github },
+    ],
+  },
+  {
+    heading: "Project",
+    links: [
+      { label: "About", href: "/about" },
+      { label: "Team", href: "/about#team" },
+      { label: "Source code", href: site.links.repo },
+    ],
+  },
+];
+
+const linkClasses = "link-quiet text-body-sm text-muted-foreground";
 
 export default function Footer() {
   return (
-    <footer className=" border-t border-border/40 bg-background/90 backdrop-blur-md">
-      <div className="mx-auto max-w-7xl px-6 py-12 md:flex md:items-center md:justify-between lg:px-8">
-        <div className="flex flex-col items-start gap-4 md:max-w-sm">
-          <Link href="/" className="flex items-center gap-2">
-            <Image
-              src="/virasat.png"
-              alt="Logo"
-              width={28}
-              height={28}
-              className="rounded-md"
-            />
-            <span className="text-lg font-bold tracking-tighter text-brand">
+    <footer className="border-border border-t">
+      <div className="border-border flex flex-wrap items-start justify-between gap-8 border-b px-6 py-12 lg:px-10">
+        <Link href="/" className="flex items-center gap-2.5">
+          <LogoMark size={32} />
+          <span className="flex flex-col">
+            <span className="font-display text-label leading-none">
               HimVirasat
             </span>
-          </Link>
-          <p className="text-sm leading-6 text-muted-foreground">
-            {`An open-source initiative dedicated to the digital preservation of Himachal's linguistic heritage and cultural memory.`}
-          </p>
-        </div>
+            <span
+              aria-hidden
+              className="font-takri text-muted-foreground mt-1 text-[10px] leading-none"
+            >
+              {site.takriName}
+            </span>
+          </span>
+        </Link>
+        <p className="text-body-sm text-muted-foreground max-w-md">
+          {site.description}
+        </p>
+      </div>
 
-        <div className="mt-8 flex flex-wrap gap-x-8 gap-y-4 md:mt-0">
-          <Link
-            href="/vocabulary"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Vocabulary
-          </Link>
-          <Link
-            href="/vocabulary"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Dialects
-          </Link>
-          <Link
-            href="https://github.com/HimVirasat"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            GitHub
-          </Link>
-          <Link
-            href="/about"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            About
-          </Link>
-        </div>
+      <RuledGrid cols={4} bordered={false} className="border-border border-b">
+        {columns.map((column) => (
+          <RuledCell key={column.heading} className="px-6 py-10 lg:px-10">
+            <Eyebrow as="h3">{column.heading}</Eyebrow>
+            <ul className="mt-5 flex flex-col gap-3">
+              {column.links.map((link) => (
+                <li key={link.label}>
+                  {link.href.startsWith("http") ? (
+                    <a
+                      href={link.href}
+                      target="_blank"
+                      rel="noreferrer"
+                      className={linkClasses}
+                    >
+                      {link.label}
+                    </a>
+                  ) : (
+                    <Link href={link.href} className={linkClasses}>
+                      {link.label}
+                    </Link>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </RuledCell>
+        ))}
+      </RuledGrid>
 
-        <div className="mt-8 md:mt-0">
-          <p className="text-xs leading-5 text-muted-foreground">
-            &copy; {new Date().getFullYear()} HimVirasat. Built by the
-            community.
-          </p>
-        </div>
+      <div className="flex flex-wrap items-center justify-between gap-x-8 gap-y-2 px-6 py-6 lg:px-10">
+        <p className="text-body-sm text-muted-foreground">
+          &copy; {new Date().getFullYear()} HimVirasat
+        </p>
+        {/* Larger than the copyright beside it on purpose: Devanagari reads
+            smaller than Latin at the same nominal size, so matching specs
+            would leave the sign-off looking undersized. */}
+        <p lang="hi" className="font-deva text-title text-muted-foreground">
+          जय देवभूमि
+        </p>
       </div>
     </footer>
   );

--- a/himvirasat-frontend/components/layout/Navbar.tsx
+++ b/himvirasat-frontend/components/layout/Navbar.tsx
@@ -1,148 +1,227 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { usePathname } from "next/navigation";
-import { Menu, X } from "lucide-react";
 import Link from "next/link";
-import Image from "next/image";
-import { SiGithub } from "@icons-pack/react-simple-icons";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 
-// TOGGLE THIS TO SWITCH MODES:
-// false = Shrinking Floating Pill
-// true  = Strict Sticky Bar
-const STRICT_STICKY = false;
+import { ThemeToggle } from "@/components/layout/theme-toggle";
+import { ArrowRow } from "@/components/mistral/arrow-row";
+import { Eyebrow } from "@/components/mistral/eyebrow";
+import { LogoMark } from "@/components/mistral/logo-mark";
+import { MegaMenu, type MenuPanel } from "@/components/mistral/mega-menu";
+import { PixelIcon } from "@/components/mistral/pixel-icon";
+import { Button } from "@/components/ui/button";
+import { dialectsConfig } from "@/lib/dialects/dialect-config";
+import { site } from "@/lib/site";
+
+const panels: MenuPanel[] = [
+  {
+    label: "Explore",
+    groups: [
+      {
+        heading: "Archive",
+        links: [
+          {
+            label: "Vocabulary",
+            href: "/vocabulary",
+            description: "Search living dictionaries by dialect.",
+          },
+          {
+            label: "Datasets",
+            href: "/datasets",
+            description: "Open, versioned translation data.",
+          },
+        ],
+      },
+      {
+        heading: "Dialects",
+        // Derived from the live config, so the menu can never advertise a
+        // dialect that has no vocabulary behind it.
+        links: dialectsConfig.map((dialect) => ({
+          label: dialect.title,
+          href: `/vocabulary/${dialect.id}`,
+          description: dialect.subtitle,
+        })),
+      },
+    ],
+  },
+  {
+    label: "Tools",
+    groups: [
+      {
+        heading: "Script",
+        links: [
+          {
+            label: "Transliterator",
+            href: "/tools/transliterator",
+            description: "Convert Devanagari to Takri and back.",
+          },
+        ],
+      },
+      {
+        heading: "Contribute",
+        links: [
+          {
+            label: "Start contributing",
+            href: "/contribute",
+            description: "Add sentences in your dialect.",
+          },
+          {
+            label: "All tools",
+            href: "/tools",
+            description: "Everything built so far.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    label: "About",
+    groups: [
+      {
+        heading: "Project",
+        links: [
+          {
+            label: "About HimVirasat",
+            href: "/about",
+            description: "Why this archive exists.",
+          },
+          {
+            label: "Team",
+            href: "/about#team",
+            description: "Who maintains it.",
+          },
+          {
+            label: "Source code",
+            href: site.links.repo,
+            description: "Open on GitHub.",
+            external: true,
+          },
+        ],
+      },
+      {
+        heading: "Community",
+        links: [
+          {
+            label: "HimVirasat Discord",
+            href: site.links.discordHimvirasat,
+            description: "Contributors and maintainers.",
+            external: true,
+          },
+          {
+            label: "HP Community Discord",
+            href: site.links.discordHpCommunity,
+            description: "The wider Himachal community.",
+            external: true,
+          },
+        ],
+      },
+    ],
+  },
+];
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
-  const [isScrolled, setIsScrolled] = useState(false);
   const pathname = usePathname();
 
-  useEffect(() => {
-    const handleScroll = () => setIsScrolled(window.scrollY > 20);
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
-
-  const navLinks = [
-    { name: "Home", href: "/" },
-    { name: "Vocabulary", href: "/vocabulary" },
-    { name: "Tools", href: "/tools" }, // ← ADD THIS
-    { name: "Contribute", href: "/contribute" },
-    { name: "About", href: "/about" },
-  ];
-
-  const headerClasses = STRICT_STICKY
-    ? `fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
-        isScrolled
-          ? "bg-white/85 dark:bg-zinc-950/90 backdrop-blur-md border-b border-border/40 py-2"
-          : "bg-transparent py-4"
-      }`
-    : `fixed left-1/2 -translate-x-1/2 z-50 transition-all duration-300 ease-in-out ${
-        isScrolled ? "top-2 w-[88%] max-w-4xl" : "top-2 w-[92%] max-w-5xl"
-      }`;
-
-  const navClasses = STRICT_STICKY
-    ? "mx-auto max-w-7xl px-6 flex items-center justify-between"
-    : `glass bg-white/85 dark:bg-zinc-950/90 rounded-full backdrop-blur-md transition-all duration-300 flex items-center justify-between ${
-        isScrolled ? "px-6 py-2 shadow-xl" : "px-8 py-4 shadow-lg"
-      }`;
+  // Nothing inside the overlay unmounts on navigation, so close it here.
+  useEffect(() => setIsOpen(false), [pathname]);
 
   return (
-    <header className={headerClasses}>
-      <nav className={navClasses}>
-        <Link href="/" className="flex items-center gap-2 group">
-          <Image
-            src="/virasat.png"
-            alt="Logo"
-            width={32}
-            height={32}
-            className="rounded-lg transition-transform group-hover:scale-110"
-          />
-          <span className="text-xl font-semibold tracking-tighter text-black dark:text-white">
-            HimVirasat
+    <header className="border-border bg-background fixed inset-x-0 top-0 z-50 border-b">
+      <nav className="flex h-16 items-stretch">
+        <Link
+          href="/"
+          className="border-border hover:bg-secondary flex shrink-0 items-center gap-2.5 border-r px-5 transition-colors"
+        >
+          <LogoMark size={28} />
+          <span className="flex flex-col">
+            <span className="font-display text-label leading-none">
+              HimVirasat
+            </span>
+            <span
+              aria-hidden
+              className="font-takri text-muted-foreground mt-1 text-[10px] leading-none"
+            >
+              {site.takriName}
+            </span>
           </span>
         </Link>
-        <div className="hidden md:flex items-center gap-4">
+
+        <MegaMenu panels={panels} />
+
+        <div className="ml-auto flex items-stretch">
+          {/* Upstream added this as an icon button using
+              `@icons-pack/react-simple-icons`. Kept as a feature, dropped
+              as a dependency: a whole icon package for one glyph, in a
+              system whose icons are all drawn on the same pixel lattice.
+              A text link also sits better in an editorial nav. */}
           <Link
-            href="https://github.com/HimVirasat"
+            href={site.links.github}
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="HimVirasat GitHub"
-            className="relative p-2 rounded-full text-foreground/70 hover:text-foreground hover:bg-foreground/5 transition-all duration-300"
+            className="border-border text-nav text-muted-foreground hover:bg-secondary hover:text-foreground hidden items-center border-l px-4 transition-colors md:flex"
           >
-            <SiGithub className="h-5 w-5" />
+            GitHub
           </Link>
-          <ul className="flex items-center gap-1">
-            {navLinks.map((link) => {
-              const isActive =
-                link.href === "/"
-                  ? pathname === "/"
-                  : pathname.startsWith(link.href);
-
-              return (
-                <Link
-                  key={link.name}
-                  href={link.href}
-                  className={`
-                  relative px-4 py-2 rounded-full text-sm font-medium transition-all duration-300
-                  ${
-                    isActive
-                      ? "text-emerald-700 dark:text-emerald-400 bg-emerald-500/10"
-                      : "text-foreground/70 hover:text-foreground hover:bg-foreground/5"
-                  }
-                `}
-                >
-                  {link.name}
-                  {isActive && (
-                    <span className="absolute bottom-1 left-1/2 -translate-x-1/2 w-1 h-1 bg-emerald-500 rounded-full animate-pulse" />
-                  )}
-                </Link>
-              );
-            })}
-          </ul>
+          <div className="border-border flex items-center border-l px-2">
+            <ThemeToggle />
+          </div>
+          <div className="hidden items-center gap-2 px-4 md:flex">
+            <Button asChild variant="secondary">
+              <Link href="/contribute">Contribute</Link>
+            </Button>
+            <Button asChild>
+              <Link href="/vocabulary">Explore vocabulary</Link>
+            </Button>
+          </div>
+          <button
+            type="button"
+            onClick={() => setIsOpen((open) => !open)}
+            aria-expanded={isOpen}
+            aria-controls="mobile-nav"
+            aria-label={isOpen ? "Close menu" : "Open menu"}
+            className="border-border hover:bg-secondary flex items-center border-l px-5 transition-colors md:hidden"
+          >
+            <PixelIcon name={isOpen ? "close" : "grid"} />
+          </button>
         </div>
-
-        <button
-          onClick={() => setIsOpen(!isOpen)}
-          className="md:hidden p-2 hover:bg-foreground/5 rounded-full transition-colors"
-          aria-label="Toggle Menu"
-        >
-          {isOpen ? <X size={20} /> : <Menu size={20} />}
-        </button>
       </nav>
 
-      <div
-        className={`
-          md:hidden absolute left-1/2 -translate-x-1/2 w-[95%]
-          bg-white/85 dark:bg-zinc-950/95 backdrop-blur-md
-          rounded-3xl p-6 shadow-2xl transition-all duration-300 origin-top
-          ${STRICT_STICKY ? "top-16" : "top-14"}
-          ${isOpen ? "opacity-100 scale-100" : "opacity-0 scale-95 pointer-events-none"}
-        `}
-      >
-        <div className="flex flex-col gap-4 text-center">
-          {navLinks.map((link) => (
-            <Link
-              key={link.name}
-              href={link.href}
-              onClick={() => setIsOpen(false)}
-              className="text-lg font-medium py-2 hover:text-emerald-600 transition-colors"
-            >
-              {link.name}
-            </Link>
+      {isOpen && (
+        <div
+          id="mobile-nav"
+          className="bg-background border-border animate-fade-slide fixed inset-x-0 top-16 bottom-0 overflow-y-auto border-t md:hidden"
+        >
+          {panels.map((panel) => (
+            <div key={panel.label} className="border-border border-b">
+              <Eyebrow className="px-4 pt-5">{panel.label}</Eyebrow>
+              <ul className="mt-2 flex flex-col">
+                {panel.groups.flatMap((group) =>
+                  group.links.map((link) => (
+                    <li key={link.href + link.label}>
+                      <ArrowRow
+                        href={link.href}
+                        label={link.label}
+                        description={link.description}
+                        external={link.external}
+                      />
+                    </li>
+                  )),
+                )}
+              </ul>
+            </div>
           ))}
-          <Link
-            href="https://github.com/HimVirasat"
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => setIsOpen(false)}
-            aria-label="HimVirasat GitHub"
-            className="flex justify-center pt-2 text-foreground/70 hover:text-foreground transition-colors"
-          >
-            <SiGithub className="h-6 w-6" />
-          </Link>
+          <div className="flex flex-col gap-3 p-4">
+            <Button asChild size="lg">
+              <Link href="/contribute">Start contributing</Link>
+            </Button>
+            <Button asChild size="lg" variant="secondary">
+              <Link href="/vocabulary">Explore the vocabulary</Link>
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
     </header>
   );
 }

--- a/himvirasat-frontend/components/layout/theme-toggle.tsx
+++ b/himvirasat-frontend/components/layout/theme-toggle.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        className={className}
+        aria-label="Toggle theme"
+        disabled
+      >
+        <Sun className="size-4" />
+      </Button>
+    );
+  }
+
+  const isDark = resolvedTheme === "dark";
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={className}
+      aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+    >
+      {isDark ? <Sun className="size-4" /> : <Moon className="size-4" />}
+    </Button>
+  );
+}

--- a/himvirasat-frontend/components/mistral/arrow-row.tsx
+++ b/himvirasat-frontend/components/mistral/arrow-row.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+import { PixelIcon } from "./pixel-icon";
+
+/**
+ * Ruled list row. At rest the arrow sits off the left edge; on hover or
+ * keyboard focus it slides in while the label shifts right to make room.
+ * The motion is defined by the `row-arrow` utility in globals.css so the
+ * timing stays identical everywhere it is used.
+ */
+export function ArrowRow({
+  href,
+  label,
+  description,
+  external,
+  className,
+}: {
+  href: string;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  external?: boolean;
+  className?: string;
+}) {
+  const inner = (
+    <>
+      <span
+        data-arrow
+        aria-hidden
+        className="absolute left-2 inline-flex w-5 shrink-0"
+      >
+        <PixelIcon name={external ? "arrow-up-right" : "chevron-right"} />
+      </span>
+      <span data-arrow-label className="flex min-w-0 flex-col gap-0.5">
+        <span className="text-label truncate">{label}</span>
+        {description && (
+          <span className="text-body-sm text-muted-foreground truncate">
+            {description}
+          </span>
+        )}
+      </span>
+      <PixelIcon
+        name={external ? "arrow-up-right" : "chevron-right"}
+        className="text-muted-foreground ml-auto size-4 shrink-0"
+      />
+    </>
+  );
+
+  const classes = cn(
+    "row-arrow ruled-cell relative flex items-center gap-3 overflow-hidden px-4 py-4 transition-colors hover:bg-secondary focus-visible:bg-secondary focus-visible:outline-none",
+    className,
+  );
+
+  if (external) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={classes}
+      >
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} className={classes}>
+      {inner}
+    </Link>
+  );
+}

--- a/himvirasat-frontend/components/mistral/dialect-marquee.tsx
+++ b/himvirasat-frontend/components/mistral/dialect-marquee.tsx
@@ -1,0 +1,72 @@
+import { Fragment } from "react";
+
+import { cn } from "@/lib/utils";
+import { devToTankri } from "@/lib/transliteration/devToTankri";
+
+/**
+ * A continuously scrolling strip of dialect names, in Latin and Takri.
+ *
+ * The track holds the sequence twice and translates by exactly -50%, so
+ * the second copy is in the first's starting position when the loop wraps
+ * and there is no visible seam. Pauses on hover; stops entirely under
+ * reduced motion, where a strip that never stops moving is exactly what a
+ * reader asked not to have.
+ */
+
+/**
+ * The dialects with active collection forms — the same six listed on
+ * /contribute, not an aspirational list.
+ */
+const DIALECTS = [
+  "Kangri",
+  "Mandeali",
+  "Kullvi",
+  "Mahasuvi",
+  "Kinnauri",
+  "Chambeali",
+];
+
+export function DialectMarquee({ className }: { className?: string }) {
+  const row = (hidden: boolean) => (
+    <div aria-hidden={hidden || undefined} className="flex shrink-0">
+      {/* Repeated so the sequence always overflows the widest viewport;
+          otherwise a short list leaves a gap before the wrap.
+
+          Two, not three. The track is one transform-animated element, so
+          its full width has to be rasterised: at three repeats it measured
+          10119 CSS px, which is 20238 device px on a 2× display — past
+          Chrome's 16384 px texture limit, where a layer falls off the
+          compositor fast path and is re-rastered instead. Two repeats put
+          one copy at ~3372 px, still wider than any real viewport, and the
+          track at ~13488 device px. Do not raise this without measuring
+          `track.getBoundingClientRect().width * devicePixelRatio`. */}
+      {Array.from({ length: 2 }).map((_, rep) =>
+        DIALECTS.map((name) => (
+          <Fragment key={`${rep}-${name}`}>
+            <span className="text-title px-6 whitespace-nowrap">{name}</span>
+            <span
+              aria-hidden
+              className="font-takri text-title text-verdant px-6 whitespace-nowrap"
+            >
+              {devToTankri(name)}
+            </span>
+          </Fragment>
+        )),
+      )}
+    </div>
+  );
+
+  return (
+    <div
+      className={cn(
+        "marquee border-border overflow-hidden border-y py-4",
+        className,
+      )}
+    >
+      <div className="marquee-track flex w-max">
+        {row(false)}
+        {row(true)}
+      </div>
+    </div>
+  );
+}

--- a/himvirasat-frontend/components/mistral/eyebrow.tsx
+++ b/himvirasat-frontend/components/mistral/eyebrow.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Uppercase monospace label that sits above a heading or names a column.
+ * The optional native-script echo is decorative and hidden from assistive
+ * tech — the Latin label is the accessible name.
+ */
+export function Eyebrow({
+  children,
+  nativeEcho,
+  size = "sm",
+  as: Tag = "p",
+  className,
+}: {
+  children: React.ReactNode;
+  nativeEcho?: string;
+  size?: "sm" | "lg";
+  as?: "p" | "span" | "h3";
+  className?: string;
+}) {
+  return (
+    <Tag
+      className={cn(
+        "font-mono text-muted-foreground inline-flex items-center gap-2 uppercase",
+        size === "lg" ? "text-eyebrow-lg" : "text-eyebrow",
+        className,
+      )}
+    >
+      <span>{children}</span>
+      {nativeEcho && (
+        <span aria-hidden className="font-takri text-[1.1em] normal-case">
+          {nativeEcho}
+        </span>
+      )}
+    </Tag>
+  );
+}

--- a/himvirasat-frontend/components/mistral/hero.tsx
+++ b/himvirasat-frontend/components/mistral/hero.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useRef } from "react";
+
+import { ArrowRow } from "@/components/mistral/arrow-row";
+import { Eyebrow } from "@/components/mistral/eyebrow";
+import { ScrollCue } from "@/components/mistral/scroll-cue";
+import { TakriMosaic } from "@/components/mistral/takri-mosaic";
+import { makeRng, seedFromString } from "@/lib/seeded-rng";
+import { devToTankri } from "@/lib/transliteration/devToTankri";
+
+/**
+ * The landing composition: a headline and the mission statement across the
+ * top, the Takri mosaic and a featured item beneath.
+ *
+ * The `data-hero` attributes and the refs are hooks for the scroll-driven
+ * timeline that arrives in a follow-up. They are deliberately left in place
+ * so that change is additive rather than a rewrite of this markup.
+ *
+ * The headline itself animates on load in pure CSS — see `char-rise` in
+ * globals.css — with its per-character delays seeded so the server and the
+ * client agree.
+ */
+
+const HEADLINE = "Himachal speaks in many tongues. We are writing them down.";
+
+const HEADLINE_LINES = [
+  "Himachal speaks in many",
+  "tongues. We are writing",
+  "them down.",
+];
+
+const MISSION = [
+  "An initiative driven by the community to preserve",
+  "Himachal Pradesh's languages, dialects, traditions",
+  "and cultural memory, and bring them into the digital age.",
+];
+
+const FEATURED = {
+  label: "Mandeali vocabulary is live",
+  description: "The first dialect archive is open to search.",
+  href: "/vocabulary/mandeali",
+};
+
+/** Characters rise from behind a per-line mask on load; delays are seeded. */
+function buildLines(text: string, lines: string[]) {
+  const rng = makeRng(seedFromString(text));
+  return lines.map((line, li) => ({
+    line,
+    lineDelay: li * 90,
+    chars: Array.from(line).map((ch, ci) => ({
+      ch,
+      delay: li * 90 + Math.round(ci * (1 + rng() * 4) * 5),
+    })),
+  }));
+}
+
+export function Hero() {
+  const lines = buildLines(HEADLINE, HEADLINE_LINES);
+
+  const root = useRef<HTMLElement>(null);
+  const sticky = useRef<HTMLDivElement>(null);
+  const title = useRef<HTMLParagraphElement>(null);
+  const leftTop = useRef<HTMLDivElement>(null);
+  const leftTopInner = useRef<HTMLDivElement>(null);
+  const leftMiddle = useRef<HTMLDivElement>(null);
+  const leftMiddleInner = useRef<HTMLDivElement>(null);
+  const rightTop = useRef<HTMLDivElement>(null);
+  const rightInner = useRef<HTMLDivElement>(null);
+  const rightContent = useRef<HTMLDivElement>(null);
+  const background = useRef<HTMLDivElement>(null);
+  const arrow = useRef<HTMLDivElement>(null);
+  const cards = useRef<HTMLDivElement>(null);
+
+  return (
+    <section
+      ref={root}
+      data-hero="root"
+      className="border-border relative border-b"
+    >
+      <div ref={sticky} className="lg:h-dvh lg:overflow-hidden">
+        {/* Row 1 — headline and mission */}
+        <div className="border-border flex flex-col border-b lg:relative lg:h-[60dvh] lg:flex-row">
+          <div
+            ref={leftTop}
+            data-hero="left-top"
+            className="flex shrink-0 flex-col justify-end overflow-hidden px-6 pt-16 pb-10 lg:w-[70%] lg:px-10 lg:pt-0"
+          >
+            {/* Everything that collapses lives inside a wrapper whose width
+                is pinned in pixels while the timeline runs. The column
+                animates to `width: 0` and clips; the wrapper never changes
+                size, so the headline cannot re-wrap. Without this the
+                paragraph reflowed to one character per line and grew from
+                176px to 3293px tall, re-laid-out on every scroll frame. */}
+            <div ref={leftTopInner} className="flex flex-col justify-end">
+              <Eyebrow
+                size="lg"
+                nativeEcho={devToTankri("हिमाचल की विरासत")}
+                className="mb-8"
+              >
+                Open language preservation
+              </Eyebrow>
+
+              {/* The real heading, for assistive tech and for search. The
+                  animated copy is decorative: split to characters it would
+                  be announced letter by letter. */}
+              <h1 className="sr-only">{HEADLINE}</h1>
+              <p
+                ref={title}
+                data-hero="title"
+                aria-hidden
+                className="font-display text-display-md md:text-display-xl max-w-4xl"
+              >
+                {lines.map(({ line, lineDelay, chars }, li) => (
+                  <span
+                    key={line}
+                    className="hero-line hero-line-grow"
+                    style={
+                      { "--line-delay": `${lineDelay}ms` } as React.CSSProperties
+                    }
+                  >
+                    {chars.map(({ ch, delay }, ci) => (
+                      <span
+                        key={`${li}-${ci}`}
+                        className="hero-char"
+                        style={
+                          { "--char-delay": `${delay}ms` } as React.CSSProperties
+                        }
+                      >
+                        {ch}
+                      </span>
+                    ))}
+                  </span>
+                ))}
+              </p>
+            </div>
+          </div>
+
+          {/* Taken out of the flex flow on desktop. As a flex sibling its
+              right edge tracked the collapsing left column, so the panel's
+              `right-0` anchor slid leftward with it and the expanded panel
+              ended up at x = -1130 instead of covering the viewport. */}
+          <div
+            ref={rightTop}
+            className="relative lg:absolute lg:top-0 lg:right-0 lg:h-full lg:w-[30%]"
+          >
+            {/* Anchored right, so growing its width expands leftward across
+                the space the collapsing left column vacates. */}
+            <div
+              ref={rightInner}
+              data-hero="right-inner"
+              className="border-border flex h-full flex-col justify-end overflow-hidden border-t px-6 py-10 lg:absolute lg:top-0 lg:right-0 lg:w-full lg:border-t-0 lg:border-b lg:border-l lg:px-10"
+            >
+              <div ref={rightContent} className="hero-mission">
+                {MISSION.map((line) => (
+                  <p
+                    key={line}
+                    className="js-hero-sentence hero-mission-line text-body-lg text-muted-foreground will-change-transform"
+                  >
+                    {line}
+                  </p>
+                ))}
+              </div>
+            </div>
+            {/* Tint that burns off as the panel takes over the viewport. */}
+            <div
+              ref={background}
+              data-hero="background"
+              aria-hidden
+              className="bg-secondary pointer-events-none absolute inset-0 -z-10"
+            />
+          </div>
+        </div>
+
+        {/* Row 2 — mosaic, cue and one featured item */}
+        <div className="flex flex-col lg:h-[40dvh] lg:flex-row">
+          <div
+            ref={leftMiddle}
+            data-hero="left-middle"
+            className="hero-fade-in relative shrink-0 overflow-hidden lg:w-[70%]"
+          >
+            {/* Pinned for the same reason as the headline: collapsing this
+                column would otherwise re-lay the mosaic's 30-cell grid on
+                every frame. `relative` so the corner labels still position
+                against the mosaic rather than the column. */}
+            <div ref={leftMiddleInner} className="relative">
+              <TakriMosaic variant="hero" seed={7} />
+
+              {/* On the reference these labels are painted inside the Lottie
+                  artwork. Ours are real text on a solid chip, the only way to
+                  stay legible over a mosaic containing both near-white and
+                  deep pine. */}
+              <Eyebrow className="js-hero-label bg-background pointer-events-none absolute bottom-3 left-3 px-2 py-0.5">
+                Open language preservation
+              </Eyebrow>
+              <Eyebrow className="js-hero-label bg-background pointer-events-none absolute right-3 bottom-3 px-2 py-0.5">
+                Himachal
+              </Eyebrow>
+            </div>
+          </div>
+
+          <div className="border-border flex flex-col justify-between overflow-hidden border-t lg:w-[30%] lg:border-t-0 lg:border-l">
+            <div ref={arrow}>
+              <ScrollCue className="items-start p-10" />
+            </div>
+            <div ref={cards} className="border-border border-t">
+              <Eyebrow className="px-4 pt-5">Featured</Eyebrow>
+              <ArrowRow
+                href={FEATURED.href}
+                label={FEATURED.label}
+                description={FEATURED.description}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/himvirasat-frontend/components/mistral/ink-band.tsx
+++ b/himvirasat-frontend/components/mistral/ink-band.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Full-bleed dark section. Stays dark in both themes — it is a structural
+ * break in the page, not a theme response. `surface-ink` re-themes the
+ * shadcn variables for everything nested inside, so buttons and hairlines
+ * within pick up the correct dark values automatically.
+ */
+export function InkBand({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"section">) {
+  return (
+    <section
+      className={cn("surface-ink border-ink-border border-y", className)}
+      {...props}
+    >
+      {children}
+    </section>
+  );
+}

--- a/himvirasat-frontend/components/mistral/logo-mark.tsx
+++ b/himvirasat-frontend/components/mistral/logo-mark.tsx
@@ -1,0 +1,61 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Brand mark: a snow-capped ridgeline built from mosaic tiles — glacial
+ * summit, sage upper slopes, forest and pine below, timber at the base.
+ * Same square unit as `PixelIcon` and `TakriMosaic`, so the mark, the
+ * icons and the mosaic all read as one alphabet.
+ *
+ * This tile table is duplicated verbatim in app/icon.tsx and
+ * app/opengraph-image.tsx — satori renders those and cannot import a
+ * React component, so all three must be changed together.
+ *
+ * Decorative — adjacent text always names the brand.
+ */
+
+/** [column, row, palette step] on a 4×4 lattice, origin top-left. */
+const TILES: Array<[number, number, number]> = [
+  [2, 0, 0],
+  [1, 1, 1],
+  [2, 1, 1],
+  [0, 2, 2],
+  [1, 2, 2],
+  [2, 2, 2],
+  [3, 2, 3],
+  [0, 3, 4],
+  [1, 3, 4],
+  [2, 3, 3],
+  [3, 3, 4],
+];
+
+/** summit → base: glacier, sage, forest, pine, timber. */
+const PEAK = ["#7ec6c6", "#7fb69b", "#2e7358", "#1c5341", "#6e4e36"];
+
+export function LogoMark({
+  size = 32,
+  className,
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 32 32"
+      width={size}
+      height={size}
+      className={cn("shrink-0 select-none", className)}
+    >
+      {TILES.map(([col, row, step]) => (
+        <rect
+          key={`${col}-${row}`}
+          x={col * 8}
+          y={row * 8}
+          width={8}
+          height={8}
+          fill={PEAK[step]}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/himvirasat-frontend/components/mistral/mega-menu.tsx
+++ b/himvirasat-frontend/components/mistral/mega-menu.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { NavigationMenu } from "radix-ui";
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { ArrowRow } from "./arrow-row";
+import { Eyebrow } from "./eyebrow";
+import { PixelIcon } from "./pixel-icon";
+
+export type MenuLink = {
+  label: string;
+  href: string;
+  description?: string;
+  external?: boolean;
+};
+
+export type MenuGroup = {
+  heading: string;
+  nativeEcho?: string;
+  links: MenuLink[];
+};
+
+export type MenuPanel = {
+  label: string;
+  groups: MenuGroup[];
+};
+
+/**
+ * Desktop navigation. Each trigger opens a ruled panel of grouped links;
+ * rows carry the same pixel-arrow hover as every other list in the system.
+ *
+ * Radix `Content` is rendered in place rather than through a shared
+ * `Viewport`, so each panel is positioned under its own trigger and no
+ * width/height animation variables are needed.
+ */
+export function MegaMenu({
+  panels,
+  className,
+}: {
+  panels: MenuPanel[];
+  className?: string;
+}) {
+  // Root is controlled so the open panel is known to React, which keeps
+  // the trigger's tint and chevron flip as ordinary conditional classes
+  // instead of `data-[state=open]:` variants.
+  const [openPanel, setOpenPanel] = useState("");
+
+  return (
+    <NavigationMenu.Root
+      delayDuration={80}
+      value={openPanel}
+      onValueChange={setOpenPanel}
+      className={cn("hidden h-full md:flex", className)}
+    >
+      <NavigationMenu.List className="flex h-full items-stretch">
+        {panels.map((panel) => {
+          const isOpen = openPanel === panel.label;
+          return (
+          <NavigationMenu.Item
+            key={panel.label}
+            value={panel.label}
+            className="relative flex"
+          >
+            <NavigationMenu.Trigger
+              className={cn(
+                "text-nav border-border hover:bg-secondary flex items-center gap-1.5 border-r px-5 transition-colors",
+                isOpen && "bg-secondary",
+              )}
+            >
+              {panel.label}
+              <PixelIcon
+                name="chevron-down"
+                className={cn(
+                  "text-muted-foreground size-3.5 transition-transform duration-300",
+                  isOpen && "rotate-180",
+                )}
+              />
+            </NavigationMenu.Trigger>
+
+            <NavigationMenu.Content className="animate-unroll-in bg-popover border-border absolute top-full left-0 z-50 w-[min(92vw,36rem)] border-x border-b">
+              <div
+                className={cn(
+                  "bg-border grid gap-px",
+                  panel.groups.length > 1 ? "sm:grid-cols-2" : "grid-cols-1",
+                )}
+              >
+                {panel.groups.map((group) => (
+                  <div key={group.heading} className="ruled-cell">
+                    <Eyebrow nativeEcho={group.nativeEcho} className="px-4 pt-4">
+                      {group.heading}
+                    </Eyebrow>
+                    <ul className="mt-2 flex flex-col">
+                      {group.links.map((link) => (
+                        <li key={link.href + link.label}>
+                          <NavigationMenu.Link asChild>
+                            <ArrowRow
+                              href={link.href}
+                              label={link.label}
+                              description={link.description}
+                              external={link.external}
+                            />
+                          </NavigationMenu.Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+          );
+        })}
+      </NavigationMenu.List>
+    </NavigationMenu.Root>
+  );
+}

--- a/himvirasat-frontend/components/mistral/pixel-icon.tsx
+++ b/himvirasat-frontend/components/mistral/pixel-icon.tsx
@@ -1,0 +1,376 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Icons drawn as 4×4 squares on a 6×6 lattice inside a 30×30 viewBox.
+ *
+ * Every icon in the system is built from the same square unit as the
+ * mosaic tiles, so arrows, chevrons and decorative blocks all read as one
+ * alphabet. Cells are grid indices; `cell()` maps an index to its
+ * user-space coordinate (5, 9, 13, 17, 21, 25).
+ */
+
+const CELL = 4;
+const cell = (i: number) => 5 + CELL * i;
+
+/** [column, row] pairs on the 6×6 lattice, origin top-left. */
+const ICONS = {
+  "chevron-right": [
+    [1, 0],
+    [2, 1],
+    [3, 2],
+    [2, 3],
+    [1, 4],
+  ],
+  "chevron-left": [
+    [3, 0],
+    [2, 1],
+    [1, 2],
+    [2, 3],
+    [3, 4],
+  ],
+  "chevron-down": [
+    [0, 1],
+    [1, 2],
+    [2, 3],
+    [3, 2],
+    [4, 1],
+  ],
+  "arrow-up-right": [
+    [0, 5],
+    [1, 4],
+    [2, 3],
+    [3, 2],
+    [4, 1],
+    [2, 1],
+    [3, 1],
+    [4, 2],
+    [4, 3],
+  ],
+  plus: [
+    [2, 0],
+    [2, 1],
+    [2, 2],
+    [2, 3],
+    [2, 4],
+    [0, 2],
+    [1, 2],
+    [3, 2],
+    [4, 2],
+  ],
+  minus: [
+    [0, 2],
+    [1, 2],
+    [2, 2],
+    [3, 2],
+    [4, 2],
+  ],
+  close: [
+    [0, 0],
+    [1, 1],
+    [2, 2],
+    [3, 3],
+    [4, 4],
+    [4, 0],
+    [3, 1],
+    [1, 3],
+    [0, 4],
+  ],
+  grid: [
+    [0, 0],
+    [2, 0],
+    [4, 0],
+    [0, 2],
+    [2, 2],
+    [4, 2],
+    [0, 4],
+    [2, 4],
+    [4, 4],
+  ],
+  /* Section markers for the six-up grid — each a distinct block figure. */
+  book: [
+    [0, 1],
+    [1, 1],
+    [2, 1],
+    [0, 2],
+    [2, 2],
+    [0, 3],
+    [1, 3],
+    [2, 3],
+    [4, 1],
+    [4, 2],
+    [4, 3],
+  ],
+  stack: [
+    [0, 1],
+    [1, 1],
+    [2, 1],
+    [3, 1],
+    [0, 3],
+    [1, 3],
+    [2, 3],
+    [3, 3],
+    [4, 2],
+  ],
+  swap: [
+    [0, 1],
+    [1, 1],
+    [2, 1],
+    [3, 0],
+    [3, 1],
+    [1, 3],
+    [2, 3],
+    [3, 3],
+    [1, 4],
+  ],
+  map: [
+    [0, 0],
+    [1, 1],
+    [2, 0],
+    [3, 1],
+    [4, 0],
+    [0, 3],
+    [1, 3],
+    [2, 3],
+    [3, 3],
+    [4, 3],
+  ],
+  quill: [
+    [4, 0],
+    [3, 1],
+    [2, 2],
+    [1, 3],
+    [0, 4],
+    [1, 4],
+    [0, 3],
+  ],
+  people: [
+    [1, 0],
+    [1, 1],
+    [0, 2],
+    [1, 2],
+    [2, 2],
+    [4, 0],
+    [4, 1],
+    [3, 2],
+    [4, 2],
+    [1, 4],
+    [3, 4],
+  ],
+
+  /* Himachali motifs. Same 4×4-square unit as everything above, so they
+     sit in the mosaic beside the Takri letters without changing register. */
+
+  /**
+   * Deodar — a solid conifer over a single-cell trunk. The trunk is what
+   * separates it from the pagoda at tile size; an earlier version widened
+   * the base and both motifs just read as crosses.
+   */
+  deodar: [
+    [2, 0],
+    [1, 1],
+    [2, 1],
+    [3, 1],
+    [1, 2],
+    [2, 2],
+    [3, 2],
+    [0, 3],
+    [1, 3],
+    [2, 3],
+    [3, 3],
+    [4, 3],
+    [2, 4],
+  ],
+
+  /**
+   * Pagoda — two roof tiers with a gap between them. The gap is the
+   * distinguishing feature: the deodar is a filled triangle, this is not.
+   */
+  pagoda: [
+    [2, 0],
+    [1, 1],
+    [2, 1],
+    [3, 1],
+    [2, 2],
+    [0, 3],
+    [1, 3],
+    [2, 3],
+    [3, 3],
+    [4, 3],
+    [1, 4],
+    [2, 4],
+    [3, 4],
+  ],
+
+  /**
+   * Kath-kuni — timber courses banded with dry-stone infill. Horizontal
+   * banding, not a chequer; the chequer version read as noise.
+   */
+  kathkuni: [
+    [0, 0],
+    [1, 0],
+    [2, 0],
+    [3, 0],
+    [4, 0],
+    [0, 1],
+    [2, 1],
+    [4, 1],
+    [0, 2],
+    [1, 2],
+    [2, 2],
+    [3, 2],
+    [4, 2],
+    [0, 3],
+    [2, 3],
+    [4, 3],
+    [0, 4],
+    [1, 4],
+    [2, 4],
+    [3, 4],
+    [4, 4],
+  ],
+
+  /** Peak — the ridgeline of the brand mark, at tile scale. */
+  peak: [
+    [2, 1],
+    [1, 2],
+    [2, 2],
+    [3, 2],
+    [0, 3],
+    [1, 3],
+    [2, 3],
+    [3, 3],
+    [4, 3],
+    [0, 4],
+    [1, 4],
+    [2, 4],
+    [3, 4],
+    [4, 4],
+  ],
+
+  /* Four more, chosen for silhouette separation rather than iconographic
+     detail. At 58% of a tile there is no room for detail — what carries is
+     the outline, so each of these breaks a different way from the four
+     above (filled triangle, gapped triangle, horizontal bands, solid
+     mountain). */
+
+  /**
+   * Charkha — an open ring with a hub. The only round, hollow-centred mark
+   * in the set, which is the whole reason it reads apart at tile size.
+   */
+  charkha: [
+    [1, 0],
+    [2, 0],
+    [3, 0],
+    [0, 1],
+    [4, 1],
+    [0, 2],
+    [2, 2],
+    [4, 2],
+    [0, 3],
+    [4, 3],
+    [1, 4],
+    [2, 4],
+    [3, 4],
+  ],
+
+  /**
+   * Shawl — the lozenge of a Kullu border. An outline, not a fill: it is
+   * the only hollow diamond in the set, which is what separates it from
+   * the solid diamond tile the mosaic also uses.
+   *
+   * An earlier version alternated cells row by row to suggest a chevron
+   * weave. On a five-wide lattice that is just a chequerboard — rendered
+   * side by side with the others it read as noise, not as a border.
+   */
+  shawl: [
+    [2, 0],
+    [1, 1],
+    [3, 1],
+    [0, 2],
+    [4, 2],
+    [1, 3],
+    [3, 3],
+    [2, 4],
+  ],
+
+  /**
+   * Terrace — stepped hill fields. The only asymmetric mark in the set;
+   * everything else is mirror-symmetric, so the lean is unmistakable even
+   * when the shape is too small to count the steps.
+   */
+  terrace: [
+    [0, 4],
+    [1, 4],
+    [2, 4],
+    [3, 4],
+    [4, 4],
+    [1, 3],
+    [2, 3],
+    [3, 3],
+    [4, 3],
+    [2, 2],
+    [3, 2],
+    [4, 2],
+    [3, 1],
+    [4, 1],
+    [4, 0],
+  ],
+
+  /**
+   * Chulha — a hearth: a solid block with the fire mouth cut out of its
+   * base. Solid where the ring and the weave are open, broken where the
+   * peak and the deodar are whole.
+   */
+  chulha: [
+    [0, 0],
+    [1, 0],
+    [2, 0],
+    [3, 0],
+    [4, 0],
+    [0, 1],
+    [1, 1],
+    [2, 1],
+    [3, 1],
+    [4, 1],
+    [0, 2],
+    [4, 2],
+    [0, 3],
+    [4, 3],
+    [0, 4],
+    [4, 4],
+  ],
+} as const;
+
+export type PixelIconName = keyof typeof ICONS;
+
+export function PixelIcon({
+  name,
+  className,
+  style,
+}: {
+  name: PixelIconName;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 30 30"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("size-5 shrink-0", className)}
+      style={style}
+    >
+      {ICONS[name].map(([col, row]) => (
+        <rect
+          key={`${col}-${row}`}
+          x={cell(col)}
+          y={cell(row)}
+          width={CELL}
+          height={CELL}
+          fill="currentColor"
+        />
+      ))}
+    </svg>
+  );
+}

--- a/himvirasat-frontend/components/mistral/ruled-grid.tsx
+++ b/himvirasat-frontend/components/mistral/ruled-grid.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Grid whose cells butt together and are separated by hairlines.
+ *
+ * The rules are drawn by a 1px gap over the container's border colour
+ * rather than by per-cell borders, so the internal lines stay exactly 1px
+ * at every column count and never double up. Cells therefore need an
+ * opaque background of their own — use `RuledCell`, or apply the
+ * `ruled-cell` class.
+ *
+ * Because the container colour shows through anywhere a cell is missing,
+ * the child count must divide evenly by every column count in `cols`. A
+ * six-item grid works at 1/2/3 columns; a four-item grid works at 1/2/4
+ * but would leave a solid band at 3.
+ */
+
+const COLUMNS = {
+  2: "grid-cols-1 sm:grid-cols-2",
+  3: "grid-cols-1 sm:grid-cols-3",
+  4: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+  "2-3": "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+  "2-4": "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+} as const;
+
+export function RuledGrid({
+  cols = 3,
+  bordered = true,
+  as: Tag = "div",
+  className,
+  children,
+}: {
+  cols?: keyof typeof COLUMNS;
+  /** Set false when the section already supplies its own outer rule. */
+  bordered?: boolean;
+  /** Use `ul`/`ol` when the cells are a genuine list. */
+  as?: "div" | "ul" | "ol";
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tag
+      className={cn(
+        "bg-border grid gap-px",
+        bordered && "border-border border",
+        COLUMNS[cols],
+        className,
+      )}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+export function RuledCell({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div className={cn("ruled-cell p-8", className)} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/himvirasat-frontend/components/mistral/scroll-cue.tsx
+++ b/himvirasat-frontend/components/mistral/scroll-cue.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+
+import { PixelIcon } from "./pixel-icon";
+
+/**
+ * Three stacked chevrons pulsing in sequence, hinting there is more below
+ * the fold. Each sits on the same 2s loop offset by 200ms, so the pulse
+ * reads as travelling downward rather than three things blinking.
+ *
+ * Decorative: the page is navigable without it, so it is hidden from
+ * assistive tech rather than announced as a control.
+ */
+export function ScrollCue({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "text-muted-foreground flex flex-col items-center gap-1",
+        className,
+      )}
+    >
+      {[0, 200, 400].map((delay) => (
+        <PixelIcon
+          key={delay}
+          name="chevron-down"
+          className="animate-arrow-cue size-4"
+          style={{ animationDelay: `${delay}ms` }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/himvirasat-frontend/components/mistral/section-heading.tsx
+++ b/himvirasat-frontend/components/mistral/section-heading.tsx
@@ -1,0 +1,49 @@
+import { cn } from "@/lib/utils";
+
+import { Eyebrow } from "./eyebrow";
+
+/**
+ * Section title. Centred by default — the display sizes are large enough
+ * that a centred axis reads as deliberate rather than decorative.
+ */
+export function SectionHeading({
+  eyebrow,
+  nativeEcho,
+  title,
+  description,
+  align = "center",
+  as: Tag = "h2",
+  className,
+}: {
+  eyebrow?: string;
+  nativeEcho?: string;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  align?: "left" | "center";
+  as?: "h1" | "h2" | "h3";
+  className?: string;
+}) {
+  const centered = align === "center";
+  return (
+    <div className={cn(centered && "text-center", className)}>
+      {eyebrow && (
+        <Eyebrow nativeEcho={nativeEcho} className="mb-5">
+          {eyebrow}
+        </Eyebrow>
+      )}
+      <Tag className="text-display-md md:text-display-xl text-balance">
+        {title}
+      </Tag>
+      {description && (
+        <p
+          className={cn(
+            "text-body-lg text-muted-foreground mt-6 max-w-prose",
+            centered && "mx-auto",
+          )}
+        >
+          {description}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/himvirasat-frontend/components/mistral/sticky-rail-section.tsx
+++ b/himvirasat-frontend/components/mistral/sticky-rail-section.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils";
+
+import { Eyebrow } from "./eyebrow";
+
+/**
+ * Deep-dive layout: a narrow index rail that sticks under the header
+ * while the wide content column scrolls past it. Ten columns, two for the
+ * rail, matching the page's underlying grid.
+ *
+ * The rail is hidden below `md` — on narrow screens it would cost more
+ * height than the orientation it buys.
+ */
+export function StickyRailSection({
+  eyebrow,
+  nativeEcho,
+  railTitle,
+  railFooter,
+  className,
+  children,
+}: {
+  eyebrow: string;
+  nativeEcho?: string;
+  railTitle: React.ReactNode;
+  railFooter?: React.ReactNode;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={cn("border-border border-t md:grid md:grid-cols-10", className)}>
+      <div className="border-border hidden md:sticky md:top-16 md:col-span-2 md:flex md:h-[calc(100dvh-4rem)] md:flex-col md:justify-between md:border-r md:px-6 md:py-12">
+        <div>
+          <Eyebrow nativeEcho={nativeEcho}>{eyebrow}</Eyebrow>
+          <p className="text-title mt-4 text-balance">{railTitle}</p>
+        </div>
+        {railFooter && (
+          <div className="text-body-sm text-muted-foreground">{railFooter}</div>
+        )}
+      </div>
+      <div className="md:col-span-8">{children}</div>
+    </section>
+  );
+}

--- a/himvirasat-frontend/components/mistral/takri-mosaic.tsx
+++ b/himvirasat-frontend/components/mistral/takri-mosaic.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+import { PixelIcon, type PixelIconName } from "@/components/mistral/pixel-icon";
+import { useReveal } from "@/hooks/use-reveal";
+import { makeRng } from "@/lib/seeded-rng";
+import { cn } from "@/lib/utils";
+
+/**
+ * Marks the node `data-in-view` so the drift loop can be paused while it is
+ * off-screen — see the rule in globals.css for why that matters.
+ *
+ * Writes the attribute directly instead of going through state: this fires
+ * on every scroll past every mosaic, and a re-render per crossing is the
+ * opposite of the point. `useReveal` is deliberately left alone; its latch
+ * is correct for content reveals, which must not un-reveal.
+ */
+function usePauseOffscreen(ref: RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || typeof IntersectionObserver === "undefined") return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) =>
+        node.setAttribute("data-in-view", String(entry.isIntersecting)),
+      // A margin either side, so a mosaic is already running by the time it
+      // is scrolled into view rather than starting mid-phase.
+      { rootMargin: "200px 0px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [ref]);
+}
+
+/**
+ * The signature graphic: a grid of flat square tiles in the Deodar palette,
+ * carrying single Takri letters and Himachali motifs, with occasional
+ * rotated diamonds. Everything is drawn on the same square unit as
+ * `PixelIcon`, so the mark, the icons and the mosaic share one alphabet.
+ *
+ * Every tile is a four-sided prism that turns a quarter at a time, and
+ * each face is dealt independently: its own colour, and its own content.
+ * A tile can carry a letter on one face, nothing on the next and a motif
+ * on the one after — which is where the appearing and disappearing icons
+ * come from. Only the turn is CSS; the deal is all here.
+ *
+ * Three invariants hold by construction rather than by checking after:
+ *
+ *   1. No colour appears more than twice in any one frame. Tones are
+ *      dealt from a bag containing exactly two copies of each, so a third
+ *      use is not representable.
+ *   2. No letter and no motif appears twice in any one frame. Both are
+ *      drawn without replacement, per frame. Across the whole turn they
+ *      may recur — with 12 letters showing at once there are not four
+ *      disjoint sets in a 42-letter block, and there are only eight
+ *      motifs.
+ *   3. Ink always pairs with the fill it sits on, because both come from
+ *      the same tone on the same face. This used to need a per-tile
+ *      polarity lock, since a fixed mark had to stay legible across four
+ *      changing colours; content that turns with the colour doesn't.
+ *
+ * The pattern is generated from a fixed seed through a pure PRNG, so the
+ * server and the client produce byte-identical markup. Never introduce
+ * `Math.random()` here — it would desynchronise hydration.
+ */
+
+type Tone = { fill: string; ink: string };
+
+const INK_DARK = "#07070b";
+const INK_CREAM = "#fbfbf8";
+
+/**
+ * Every fill below was checked against both inks. AA at 4.5:1 needs
+ * relative luminance >= 0.185 for near-black ink or <= 0.175 for cream;
+ * a tone between those is unusable with either. None are. Worst pairing
+ * is clay-500 at 4.90:1. Adding a tone means redoing that arithmetic.
+ */
+const DARK_INK: Tone[] = [
+  { fill: "#a9cfbc", ink: INK_DARK }, // pine 50
+  { fill: "#7fb69b", ink: INK_DARK }, // pine 100 — sage
+  { fill: "#64a687", ink: INK_DARK }, // pine 200
+  { fill: "#4e9578", ink: INK_DARK }, // pine 300 — meadow
+  { fill: "#b9dedc", ink: INK_DARK }, // glacier 100 — pale ice
+  { fill: "#7ec6c6", ink: INK_DARK }, // glacier 300
+  { fill: "#5cb0b4", ink: INK_DARK }, // glacier 400
+  { fill: "#3e9ca3", ink: INK_DARK }, // glacier 500
+  { fill: "#d3b79b", ink: INK_DARK }, // clay 200 — sand
+  { fill: "#a98363", ink: INK_DARK }, // clay 400
+  { fill: "#b7bdb6", ink: INK_DARK }, // stone 300 — slate
+];
+
+const CREAM_INK: Tone[] = [
+  { fill: "#2e7358", ink: INK_CREAM }, // pine 500 — forest
+  { fill: "#1c5341", ink: INK_CREAM }, // pine 700
+  { fill: "#0f3a2e", ink: INK_CREAM }, // pine 900 — deep pine
+  { fill: "#2a7480", ink: INK_CREAM }, // glacier 700
+  { fill: "#8b6749", ink: INK_CREAM }, // clay 500
+  { fill: "#6e4e36", ink: INK_CREAM }, // clay 600 — timber
+  { fill: "#4a3324", ink: INK_CREAM }, // clay 800
+  { fill: "#5d6660", ink: INK_CREAM }, // stone 600
+];
+
+/**
+ * Snow. Read from tokens rather than literals so they invert with the
+ * theme — near-white on the dark canvas, warm paper on the light one.
+ * Seven steps because the band variant carries thirteen neutral tiles and
+ * the cap of two per colour means three tones could only cover six.
+ */
+const SNOW: Tone[] = Array.from({ length: 7 }, (_, i) => ({
+  fill: `var(--mosaic-${i + 1})`,
+  ink: INK_DARK,
+}));
+
+const TINTED = [...DARK_INK, ...CREAM_INK];
+const ALL_TONES = [...TINTED, ...SNOW];
+
+/** Takri, U+11680–U+116A9. Forty-two letters, drawn without replacement. */
+const GLYPHS = Array.from({ length: 0x116a9 - 0x11680 + 1 }, (_, i) =>
+  String.fromCodePoint(0x11680 + i),
+);
+
+/** Himachali motifs, in the same pixel grammar as the icons. */
+const MOTIFS: PixelIconName[] = [
+  "deodar",
+  "pagoda",
+  "kathkuni",
+  "peak",
+  "charkha",
+  "shawl",
+  "terrace",
+  "chulha",
+];
+
+/**
+ * Marks are accents on a mostly quiet grid, not the substance of it —
+ * roughly a third of the tiles carry anything. An earlier pass marked
+ * three fifths of them and the mosaic read as clutter.
+ *
+ * `tinted` is not a free knob. Whatever is not tinted is snow, and snow
+ * has 7 tones against a cap of two uses each — 14 slots. Dropping
+ * `tinted` to 0.45 here put 16 neutral tiles against those 14 slots, the
+ * bag ran dry, and the cap silently broke at four uses of one colour.
+ * Every variant must leave `tiles * (1 - tinted) <= 14`.
+ */
+const VARIANTS = {
+  hero: {
+    tiles: 30,
+    cols: "grid-cols-6 sm:grid-cols-10",
+    waveCols: 10,
+    tinted: 0.55, // 17 tinted / 13 snow
+    glyphs: 6,
+    motifs: 2,
+    diamonds: 1,
+  },
+  band: {
+    tiles: 24,
+    cols: "grid-cols-6 sm:grid-cols-12",
+    waveCols: 12,
+    tinted: 0.45, // 11 tinted / 13 snow
+    glyphs: 4,
+    motifs: 2,
+    diamonds: 1,
+  },
+  panel: {
+    tiles: 16,
+    cols: "grid-cols-4",
+    waveCols: 4,
+    tinted: 0.5, // 8 tinted / 8 snow
+    glyphs: 3,
+    motifs: 1,
+    diamonds: 1,
+  },
+} as const;
+
+const PHASES = 4;
+
+/** Fisher–Yates against the seeded PRNG. */
+function shuffle<T>(items: T[], rng: () => number): T[] {
+  const a = [...items];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+type Kind = "glyph" | "motif" | "diamond" | "plain";
+
+export function TakriMosaic({
+  variant = "hero",
+  seed = 7,
+  className,
+}: {
+  variant?: keyof typeof VARIANTS;
+  /** Change to reshuffle the pattern; must be stable across renders. */
+  seed?: number;
+  className?: string;
+}) {
+  const v = VARIANTS[variant];
+  const { ref, revealed } = useReveal<HTMLDivElement>();
+  usePauseOffscreen(ref);
+  const rng = makeRng(seed);
+
+  // Every face of every tile is dealt independently. One pass per phase,
+  // each pass a self-contained frame that has to satisfy the invariants on
+  // its own — which is exactly what "nothing repeats on screen" means when
+  // what is on screen changes four times a loop.
+  type Face = { fill: string; ink: string; kind: Kind; glyph: string | null; motif: PixelIconName | null };
+  const faces: Face[][] = [];
+
+  for (let p = 0; p < PHASES; p++) {
+    // Which tiles are tinted this frame, and what each of them carries.
+    const order = shuffle(
+      Array.from({ length: v.tiles }, (_, i) => i),
+      rng,
+    );
+    const tintedOrder = order.slice(0, Math.round(v.tiles * v.tinted));
+    const tintedSet = new Set(tintedOrder);
+
+    const kinds = new Map<number, Kind>();
+    let cursor = 0;
+    for (let n = 0; n < v.glyphs && cursor < tintedOrder.length; n++)
+      kinds.set(tintedOrder[cursor++], "glyph");
+    for (let n = 0; n < v.motifs && cursor < tintedOrder.length; n++)
+      kinds.set(tintedOrder[cursor++], "motif");
+    for (let n = 0; n < v.diamonds && cursor < tintedOrder.length; n++)
+      kinds.set(tintedOrder[cursor++], "diamond");
+
+    // Drawn without replacement, so neither a letter nor a motif can show
+    // up twice in the same frame. Counts are set per variant to stay well
+    // inside both pools: 42 letters against at most 12, 8 motifs against
+    // at most 4.
+    const letters = shuffle(GLYPHS, rng).slice(0, v.glyphs);
+    const motifs = shuffle(MOTIFS, rng).slice(0, v.motifs);
+
+    // A bag holding exactly two copies of every tone. A tile takes the
+    // first tone the bag offers that its pool allows, so a third use of
+    // any colour is not representable. Marked tiles draw from the full
+    // tinted range now — the old polarity lock existed only because a
+    // fixed mark had to survive four colour changes.
+    const bag = shuffle(
+      ALL_TONES.flatMap((t) => [t, t]),
+      rng,
+    );
+    const row: Face[] = [];
+    const used = new Map<string, number>();
+    for (let i = 0; i < v.tiles; i++) {
+      const allowed = tintedSet.has(i) ? TINTED : SNOW;
+      const at = bag.findIndex((t) => allowed.includes(t));
+      // The variants are sized so the bag never runs dry. If a future one
+      // is not, take the least-used tone rather than the first: the cap
+      // then degrades by one instead of landing every overflow on the
+      // same colour, which is how it broke at four uses of one snow tone.
+      const tone =
+        at >= 0
+          ? bag.splice(at, 1)[0]
+          : allowed.reduce((best, t) =>
+              (used.get(t.fill) ?? 0) < (used.get(best.fill) ?? 0) ? t : best,
+            );
+      used.set(tone.fill, (used.get(tone.fill) ?? 0) + 1);
+      const kind: Kind = kinds.get(i) ?? "plain";
+      row.push({
+        fill: tone.fill,
+        ink: tone.ink,
+        kind,
+        glyph: kind === "glyph" ? (letters.pop() ?? null) : null,
+        motif: kind === "motif" ? (motifs.pop() ?? null) : null,
+      });
+    }
+    faces.push(row);
+  }
+
+  // Turn slots: a shuffled queue of evenly spaced positions across one
+  // quarter-loop. Even spacing is what holds the count of simultaneous
+  // turns steady — drawing each offset at random instead would clump, and
+  // the mosaic would alternate between motionless and half of it moving.
+  // Shuffling keeps the order off the grid, so it reads as scattered
+  // rather than as a sweep.
+  const slotOrder = shuffle(
+    Array.from({ length: v.tiles }, (_, i) => i),
+    rng,
+  );
+
+  const cells = Array.from({ length: v.tiles }, (_, i) => ({
+    faces: faces.map((row) => row[i]),
+    // Diagonal wave, so variants that animate an entrance land as one
+    // gesture rather than trickling across in DOM order.
+    wave: Math.floor(i / v.waveCols) + (i % v.waveCols),
+    turnSlot: slotOrder[i] / v.tiles,
+    // Left, right, up or down.
+    axis: rng() < 0.5 ? "x" : "y",
+    dir: rng() < 0.5 ? "reverse" : "normal",
+  }));
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden
+      data-mosaic={variant}
+      data-revealed={revealed}
+      className={cn("grid w-full", v.cols, className)}
+    >
+      {cells.map((c, i) => (
+        <div
+          key={i}
+          data-kind={c.faces[0].kind}
+          className="mosaic-tile relative aspect-square"
+          style={
+            {
+              // A face is exactly edge-on for an instant on each quarter
+              // turn, and a tile with no background of its own shows the
+              // page through that slit — a black crack across a light
+              // mosaic. Backing the tile means the turn reveals a tile
+              // edge in the palette instead of a hole.
+              backgroundColor: c.faces[0].fill,
+              "--i": c.wave,
+              "--turn-slot": c.turnSlot,
+            } as React.CSSProperties
+          }
+        >
+          <div className="mosaic-cube" data-axis={c.axis} data-dir={c.dir}>
+            {c.faces.map((f, p) => (
+              <div
+                key={p}
+                data-face={p}
+                data-kind={f.kind}
+                className="mosaic-face"
+                style={{
+                  backgroundColor: f.fill,
+                  // Quarter turns around whichever axis this tile turns
+                  // on, each face pushed out to the prism's surface.
+                  //
+                  // The depth is not optional, even with no perspective.
+                  // A face at depth d rotated by θ projects to x = d·sinθ,
+                  // so at d = 0 all four faces share one hinge down the
+                  // middle of the tile and open outward from it instead of
+                  // riding round. Half the tile's width puts them on the
+                  // surface; `cqw` resolves against the tile itself.
+                  transform:
+                    c.axis === "x"
+                      ? `rotateX(${p * 90}deg) translateZ(50cqw)`
+                      : `rotateY(${p * 90}deg) translateZ(50cqw)`,
+                }}
+              >
+                {f.glyph && (
+                  <span
+                    className="font-takri text-[clamp(1rem,3.2vw,2.75rem)] leading-none select-none"
+                    style={{ color: f.ink }}
+                  >
+                    {f.glyph}
+                  </span>
+                )}
+                {f.motif && (
+                  <PixelIcon
+                    name={f.motif}
+                    className="size-[58%]"
+                    style={{ color: f.ink }}
+                  />
+                )}
+                {f.kind === "diamond" && (
+                  <span
+                    className="mosaic-diamond block size-[52%] rotate-45"
+                    style={{ backgroundColor: f.ink }}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/himvirasat-frontend/components/motion/reveal.tsx
+++ b/himvirasat-frontend/components/motion/reveal.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import type { CSSProperties } from "react";
+
+import { useReveal } from "@/hooks/use-reveal";
+
+/**
+ * Scroll-reveal wrapper. Children stay server-rendered; this only toggles
+ * data attributes consumed by the reveal CSS in globals.css.
+ */
+export function Reveal({
+  as: Tag = "div",
+  delay = 0,
+  className,
+  children,
+}: {
+  as?: "div" | "section" | "li" | "span";
+  delay?: number;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const { ref, revealed } = useReveal<HTMLDivElement>();
+  return (
+    <Tag
+      ref={ref as never}
+      data-reveal
+      data-revealed={revealed}
+      className={className}
+      style={{ "--reveal-delay": `${delay}ms` } as CSSProperties}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/himvirasat-frontend/components/tools/tool-card.tsx
+++ b/himvirasat-frontend/components/tools/tool-card.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+import { PixelIcon } from "@/components/mistral/pixel-icon";
+
+/** Card linking to a language tool, with an optional Takri glyph tile. */
+export function ToolCard({
+  href,
+  title,
+  description,
+  glyph,
+}: {
+  href: string;
+  title: string;
+  description: string;
+  glyph?: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="ruled-cell hover:bg-secondary group flex h-full flex-col p-8 transition-colors focus-visible:outline-none focus-visible:bg-secondary"
+    >
+      {glyph && (
+        <span
+          aria-hidden
+          className="bg-pine-100 font-takri mb-6 grid size-14 place-items-center text-3xl text-[#07070b]"
+        >
+          {glyph}
+        </span>
+      )}
+      <h2 className="text-title">{title}</h2>
+      <p className="text-body-sm text-muted-foreground mt-2 flex-1">
+        {description}
+      </p>
+      <PixelIcon
+        name="chevron-right"
+        className="text-muted-foreground mt-6 size-4 transition-transform duration-300 group-hover:translate-x-1"
+      />
+    </Link>
+  );
+}

--- a/himvirasat-frontend/components/transliterator/Transliterator.tsx
+++ b/himvirasat-frontend/components/transliterator/Transliterator.tsx
@@ -1,81 +1,143 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
+
+import { Eyebrow } from "@/components/mistral/eyebrow";
+import { PixelIcon } from "@/components/mistral/pixel-icon";
+import { Button } from "@/components/ui/button";
 import { devToTankri } from "@/lib/transliteration/devToTankri";
 import { tankriToDev } from "@/lib/transliteration/tankriToDev";
+import { cn } from "@/lib/utils";
+
+const EXAMPLES = ["नमस्ते", "हिमाचल", "पहाड़", "मंडी"];
+
+// The pane itself is the ruled cell, so the field carries no border of its
+// own — the hairline grid supplies all the structure.
+const fieldBase =
+  "w-full flex-1 resize-y bg-transparent outline-none placeholder:text-muted-foreground min-h-40 md:min-h-52";
 
 export default function Transliterator() {
   const [devText, setDevText] = useState("");
   const [tankriText, setTankriText] = useState("");
-  const [lastEdited, setLastEdited] = useState<"dev" | "tankri" | null>(null);
+  const [swapped, setSwapped] = useState(false);
 
   const handleDevChange = (value: string) => {
-    setLastEdited("dev");
     setDevText(value);
     setTankriText(devToTankri(value));
   };
 
   const handleTankriChange = (value: string) => {
-    setLastEdited("tankri");
     setTankriText(value);
     setDevText(tankriToDev(value));
   };
 
-  const copyToClipboard = async (text: string) => {
+  const copyText = async (text: string, script: "Devanagari" | "Takri") => {
     try {
       await navigator.clipboard.writeText(text);
+      toast(`Copied ${script} text`);
     } catch (err) {
       console.error("Copy failed", err);
     }
   };
 
+  const clearAll = () => {
+    setDevText("");
+    setTankriText("");
+  };
+
+  const bothEmpty = devText === "" && tankriText === "";
+
   return (
-    <div className="w-full max-w-5xl mx-auto glass rounded-2xl p-6 md:p-8 shadow">
-      <h2 className="text-2xl font-semibold">Transliteration Tool</h2>
-
-      <p className="mt-2 text-sm opacity-70 max-w-xl">
-        Type in either box. The other will update automatically.
-      </p>
-
-      <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
-        {/* Devanagari */}
-        <div className="flex flex-col">
-          <label className="text-sm font-medium mb-1">Devanagari</label>
+    <div className="border-border border">
+      <div className="bg-border grid gap-px md:grid-cols-2">
+        <div
+          className={cn(
+            "ruled-cell flex flex-col gap-3 p-6",
+            swapped ? "md:order-2" : "md:order-1",
+          )}
+        >
+          <div className="flex items-center gap-2">
+            <Eyebrow nativeEcho="देवनागरी">Devanagari</Eyebrow>
+            <span className="text-body-sm text-muted-foreground ml-auto tabular-nums">
+              {devText.length}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={devText === ""}
+              onClick={() => copyText(devText, "Devanagari")}
+            >
+              Copy
+            </Button>
+          </div>
           <textarea
             value={devText}
             onChange={(e) => handleDevChange(e.target.value)}
-            placeholder="Type Devanagari here..."
-            className="h-40 rounded-lg border p-3 bg-white/70 dark:bg-zinc-900/70 resize-none focus:outline-none"
+            placeholder="यहाँ लिखें…"
+            aria-label="Devanagari text"
+            className={cn(fieldBase, "font-deva text-lg")}
           />
-          <button
-            onClick={() => copyToClipboard(devText)}
-            className="mt-2 text-sm px-3 py-1 rounded bg-emerald-600 text-white hover:bg-emerald-700 self-start"
-          >
-            Copy
-          </button>
         </div>
 
-        {/* Tankri */}
-        <div className="flex flex-col">
-          <label className="text-sm font-medium mb-1">Tankri</label>
+        <div
+          className={cn(
+            "ruled-cell flex flex-col gap-3 p-6",
+            swapped ? "md:order-1" : "md:order-2",
+          )}
+        >
+          <div className="flex items-center gap-2">
+            <Eyebrow nativeEcho="𑚔𑚭𑚊𑚤𑚯">Takri</Eyebrow>
+            <span className="text-body-sm text-muted-foreground ml-auto tabular-nums">
+              {tankriText.length}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={tankriText === ""}
+              onClick={() => copyText(tankriText, "Takri")}
+            >
+              Copy
+            </Button>
+          </div>
           <textarea
             value={tankriText}
             onChange={(e) => handleTankriChange(e.target.value)}
-            placeholder="Type Tankri here..."
-            className="h-40 rounded-lg border p-3 bg-white/70 dark:bg-zinc-900/70 resize-none focus:outline-none"
+            placeholder="Takri output…"
+            aria-label="Takri text"
+            className={cn(fieldBase, "font-takri text-xl leading-relaxed")}
           />
-          <button
-            onClick={() => copyToClipboard(tankriText)}
-            className="mt-2 text-sm px-3 py-1 rounded bg-emerald-600 text-white hover:bg-emerald-700 self-start"
-          >
-            Copy
-          </button>
         </div>
       </div>
 
-      <p className="mt-6 text-xs opacity-60">
-        This is a basic transliteration tool. Please verify outputs before
-        using.
+      <div className="border-border flex flex-wrap items-center gap-2 border-t p-4">
+        <Button variant="secondary" size="sm" onClick={() => setSwapped((s) => !s)}>
+          <PixelIcon
+            name="swap"
+            className={cn("size-4 transition-transform", swapped && "rotate-180")}
+          />
+          Swap panes
+        </Button>
+        <Button variant="ghost" size="sm" disabled={bothEmpty} onClick={clearAll}>
+          Clear
+        </Button>
+
+        <span className="text-body-sm text-muted-foreground ml-auto">Try:</span>
+        {EXAMPLES.map((word) => (
+          <button
+            key={word}
+            type="button"
+            lang="hi"
+            onClick={() => handleDevChange(word)}
+            className="border-border font-deva hover:bg-secondary rounded-md border px-3 py-1 text-sm transition-colors"
+          >
+            {word}
+          </button>
+        ))}
+      </div>
+
+      <p className="text-body-sm text-muted-foreground border-border border-t px-4 py-3">
+        This is a basic transliteration tool. Please verify outputs before use.
       </p>
     </div>
   );

--- a/himvirasat-frontend/components/ui/breadcrumb.tsx
+++ b/himvirasat-frontend/components/ui/breadcrumb.tsx
@@ -1,0 +1,109 @@
+import * as React from "react";
+import { Slot } from "radix-ui";
+import { ChevronRight, MoreHorizontal } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1.5", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : "a";
+
+  return (
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn("hover:text-foreground transition-colors", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("text-foreground font-normal", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  );
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  );
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+};

--- a/himvirasat-frontend/components/ui/button.tsx
+++ b/himvirasat-frontend/components/ui/button.tsx
@@ -4,29 +4,29 @@ import { Slot } from "radix-ui";
 
 import { cn } from "@/lib/utils";
 
+// Small radius, tight padding, no elevation. `secondary` is the 5%-ink
+// fill that pairs with the solid `default` in every CTA pair.
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "text-nav inline-flex shrink-0 items-center justify-center gap-2 rounded-md whitespace-nowrap transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/30",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          "border border-border bg-transparent hover:bg-secondary hover:text-foreground",
+        secondary: "bg-foreground/5 text-foreground hover:bg-foreground/10",
+        ghost: "hover:bg-secondary hover:text-foreground",
+        link: "text-foreground underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        default: "h-9 px-3 py-2",
+        xs: "h-6 gap-1 px-2 text-eyebrow [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-8 gap-1.5 px-2.5",
+        lg: "text-label h-11 px-5",
         icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-xs": "size-6 [&_svg:not([class*='size-'])]:size-3",
         "icon-sm": "size-8",
         "icon-lg": "size-10",
       },

--- a/himvirasat-frontend/components/ui/card.tsx
+++ b/himvirasat-frontend/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-lg border py-6",
         className
       )}
       {...props}

--- a/himvirasat-frontend/components/vocabulary/VocabularyCard.tsx
+++ b/himvirasat-frontend/components/vocabulary/VocabularyCard.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import type { VocabularyEntry } from "@/types/vocabulary/vocabulary-types";
-import { memo, useState } from "react";
+import { memo } from "react";
+import { toast } from "sonner";
+
+import { Eyebrow } from "@/components/mistral/eyebrow";
 import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { Copy, Search, MapPin, User } from "lucide-react";
 import { cleanText } from "@/lib/vocabulary/search-vocabulary";
+import type { VocabularyEntry } from "@/types/vocabulary/vocabulary-types";
 
 function escapeRegExp(s: string) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -29,13 +26,13 @@ function highlightText(text: string, query: string) {
         regex.test(part) ? (
           <mark
             key={i}
-            className="bg-amber-200/60 rounded px-0.5 dark:bg-gray-400"
+            className="bg-pine-100 rounded-none px-0.5 text-[#07070b]"
           >
             {part}
           </mark>
         ) : (
           <span key={i}>{part}</span>
-        )
+        ),
       )}
     </>
   );
@@ -50,77 +47,54 @@ export default memo(function VocabularyCard({
   query: string;
   onSearch: (word: string) => void;
 }) {
-  const [copied, setCopied] = useState(false);
-
   const handleCopy = () => {
     navigator.clipboard.writeText(entry.word_native);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1200);
+    toast("Copied");
   };
 
   return (
-    <div className="min-w-0 overflow-hidden border border-border rounded-xl bg-card text-card-foreground p-6 space-y-4 hover:bg-muted/95 transition-colors duration-200">
-      {/* Word + Meaning */}
-      <div className="min-w-0">
-        <h2 className="text-3xl sm:text-2xl font-semibold leading-snug break-all">
-          {highlightText(entry.word_native, query)}
-        </h2>
+    <article className="ruled-cell min-w-0 p-6 lg:p-8">
+      <h2 className="font-deva text-3xl leading-snug break-words" lang="hi">
+        {highlightText(entry.word_native, query)}
+      </h2>
+      <Eyebrow className="mt-2 break-words">
+        {highlightText(entry.word_meaning_en, query)}
+      </Eyebrow>
 
-        <p className="text-lg mt-1 text-green-500 font-semibold break-words">
-          {highlightText(entry.word_meaning_en, query)}
-        </p>
-      </div>
-
-      {/* Sentences */}
-      <div className="space-y-1 min-w-0">
-        <p className="text-base leading-relaxed break-words">
+      <div className="border-hairline-strong mt-5 border-l pl-5">
+        <p className="font-deva text-body break-words" lang="hi">
           {highlightText(entry.sentence_native, query)}
         </p>
-
-        <p className="text-sm text-muted-foreground leading-relaxed break-words">
+        <p className="text-body-sm text-muted-foreground mt-1 break-words">
           {highlightText(entry.sentence_meaning_en, query)}
         </p>
       </div>
 
-      {/* Metadata */}
-      <div className="flex flex-wrap items-center gap-6 text-xs text-muted-foreground min-w-0">
-        <span className="flex items-center gap-1 break-words">
-          <MapPin className="h-3 w-3 shrink-0" />
-          {entry.region || "Region not specified"}
-        </span>
+      <div className="mt-5 flex flex-wrap items-center gap-2">
+        {entry.region && (
+          <span className="animate-pop-in border-border text-body-sm text-muted-foreground rounded-md border px-2.5 py-0.5">
+            {entry.region}
+          </span>
+        )}
+        {entry.contributor_username && (
+          <span className="animate-pop-in border-border text-body-sm text-muted-foreground rounded-md border px-2.5 py-0.5">
+            {entry.contributor_username}
+          </span>
+        )}
 
-        <span className="flex items-center gap-1 break-words">
-          <User className="h-3 w-3 shrink-0" />
-          {entry.contributor_username || "Anonymous"}
-        </span>
+        <div className="ml-auto flex gap-1">
+          <Button variant="ghost" size="sm" onClick={handleCopy}>
+            Copy
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onSearch(cleanText(entry.word_native))}
+          >
+            Find similar
+          </Button>
+        </div>
       </div>
-
-      {/* Actions */}
-      <div className="flex flex-wrap gap-3 pt-2">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button size="sm" variant="outline" onClick={handleCopy}>
-              <Copy className="h-3.5 w-3.5 mr-1 shrink-0" />
-              {copied ? "Copied" : "Copy"}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>{copied ? "Copied!" : "Copy word"}</TooltipContent>
-        </Tooltip>
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => onSearch(cleanText(entry.word_native))}
-            >
-              <Search className="h-3.5 w-3.5 mr-1 shrink-0" />
-              Search
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Search this word</TooltipContent>
-        </Tooltip>
-      </div>
-    </div>
+    </article>
   );
 });

--- a/himvirasat-frontend/components/vocabulary/VocabularySearch.tsx
+++ b/himvirasat-frontend/components/vocabulary/VocabularySearch.tsx
@@ -1,20 +1,19 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useEffect, useMemo, useRef, useState, useDeferredValue } from "react";
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import searchVocabulary from "@/lib/vocabulary/search-vocabulary";
 import { VocabularyEntry } from "@/types/vocabulary/vocabulary-types";
 import { datasetFilesMap } from "@/lib/dialects/dialect-config";
 
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 
 const VocabularyCard = dynamic(
   () => import("@/components/vocabulary/VocabularyCard"),
   {
-    loading: () => <Skeleton className="h-28 w-full rounded-xl" />,
+    loading: () => <Skeleton className="h-28 w-full rounded-md" />,
     ssr: false,
   }
 );
@@ -49,61 +48,64 @@ export default function VocabularySearch({ dialect }: { dialect: string }) {
   }, [data, deferredQuery, dialect]);
 
   return (
-    <section className="w-full space-y-6">
-      <div className="flex gap-3 max-w-2xl">
+    <section className="w-full">
+      <div className="relative max-w-2xl">
         <Input
           ref={inputRef}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={`Search ${dialect} vocabulary…`}
-          className="h-14 text-base bg-white/5 border-white/10 text-white placeholder:text-slate-300 focus:ring-emerald-500 rounded-xl"
+          className="border-border bg-background h-14 rounded-md pr-24 pl-4 text-base"
         />
-
-        <Button
-          variant="outline"
-          onClick={() => {
-            setQuery("");
-            inputRef.current?.focus();
-          }}
-          className="h-14 px-6 bg-white/5 border-white/10 hover:bg-white/10 text-slate-200 rounded-xl"
-        >
-          Clear
-        </Button>
+        {query && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="absolute top-1/2 right-2 -translate-y-1/2"
+            onClick={() => {
+              setQuery("");
+              inputRef.current?.focus();
+            }}
+          >
+            Clear
+          </Button>
+        )}
       </div>
 
-      <div className="text-sm text-slate-300">
+      <p className="text-body-sm text-muted-foreground mt-3 tabular-nums">
         {loading
-          ? `Loading ${dialect} heritage...`
-          : query.trim()
-            ? `Found ${results.length} matches`
-            : `Showing all ${data.length} entries`}
-      </div>
+          ? `Loading ${dialect} vocabulary…`
+          : `${results.length} of ${data.length} entries`}
+      </p>
 
-      <ScrollArea className="h-[60vh] w-full pr-4">
-        <div className="space-y-4 pb-10">
-          {results.length > 0 ? (
-            results.map((entry, idx) => (
-              <VocabularyCard
-                key={`${entry.word_native}-${idx}`}
-                entry={entry}
-                query={deferredQuery}
-                onSearch={setQuery}
-              />
-            ))
-          ) : !loading ? (
-            <div className="text-center py-20 text-slate-300">
-              {`No matches found for "${query}"`}
+      {/* Entries read as one continuous ruled table rather than a stack of
+          floating cards — the hairlines carry the structure. */}
+      <div className="border-border bg-border mt-8 grid gap-px border">
+        {results.length > 0 ? (
+          results.map((entry, idx) => (
+            <VocabularyCard
+              key={`${entry.word_native}-${idx}`}
+              entry={entry}
+              query={deferredQuery}
+              onSearch={setQuery}
+            />
+          ))
+        ) : !loading ? (
+          <div className="ruled-cell px-6 py-16 text-center">
+            <p className="text-body">No matches. Try a shorter fragment.</p>
+            <p className="text-body-sm text-muted-foreground mt-2">
+              Search is fuzzy: partial words and approximate spellings still
+              match.
+            </p>
+          </div>
+        ) : (
+          Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="ruled-cell">
+              <div className="bg-muted h-28 animate-pulse" />
             </div>
-          ) : (
-            Array.from({ length: 5 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-28 bg-white/5 animate-pulse rounded-xl"
-              />
-            ))
-          )}
-        </div>
-      </ScrollArea>
+          ))
+        )}
+      </div>
     </section>
   );
 }

--- a/himvirasat-frontend/hooks/use-reveal.ts
+++ b/himvirasat-frontend/hooks/use-reveal.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Reveals an element the first time it enters the viewport.
+ * Falls back to immediately-revealed when IntersectionObserver is missing.
+ */
+export function useReveal<T extends HTMLElement>() {
+  const ref = useRef<T>(null);
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    if (typeof IntersectionObserver === "undefined") {
+      setRevealed(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setRevealed(true);
+            observer.disconnect();
+          }
+        }
+      },
+      { threshold: 0.15, rootMargin: "0px 0px -10% 0px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, revealed };
+}

--- a/himvirasat-frontend/lib/dialects/dialect-config.ts
+++ b/himvirasat-frontend/lib/dialects/dialect-config.ts
@@ -1,6 +1,7 @@
 export interface DialectConfig {
   id: string;
   title: string;
+  nativeName?: string;
   subtitle: string;
   backgroundImage: string;
   datasetPath: string;
@@ -10,6 +11,7 @@ export const dialectsConfig: DialectConfig[] = [
   {
     id: "mandeali",
     title: "Mandeali",
+    nativeName: "मंडयाली",
     subtitle: "Mandi region",
     backgroundImage: "/bg-mandeali.png",
     datasetPath: "/datasets/dummy.json",

--- a/himvirasat-frontend/lib/fonts.ts
+++ b/himvirasat-frontend/lib/fonts.ts
@@ -1,0 +1,56 @@
+import {
+  Geist,
+  Inter,
+  Noto_Sans_Takri,
+  Noto_Serif_Devanagari,
+  Space_Mono,
+} from "next/font/google";
+
+/** Body copy. */
+export const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+  display: "swap",
+});
+
+/**
+ * Display sizes only — headings, wordmark, section titles. A neutral
+ * neo-grotesque: large x-height, even colour, and no novelty letterforms,
+ * which is what keeps the big sizes reading as composed rather than loud.
+ */
+export const geist = Geist({
+  subsets: ["latin"],
+  variable: "--font-geist",
+  display: "swap",
+});
+
+/** Uppercase eyebrows and field labels. */
+export const spaceMono = Space_Mono({
+  weight: ["400", "700"],
+  subsets: ["latin"],
+  variable: "--font-space-mono",
+  display: "swap",
+});
+
+export const notoSerifDevanagari = Noto_Serif_Devanagari({
+  subsets: ["devanagari"],
+  variable: "--font-noto-serif-deva",
+  display: "swap",
+  preload: false,
+});
+
+export const notoSansTakri = Noto_Sans_Takri({
+  weight: "400",
+  subsets: ["takri"],
+  variable: "--font-noto-takri",
+  display: "swap",
+  preload: false,
+});
+
+export const fontVariables = [
+  inter.variable,
+  geist.variable,
+  spaceMono.variable,
+  notoSerifDevanagari.variable,
+  notoSansTakri.variable,
+].join(" ");

--- a/himvirasat-frontend/lib/seeded-rng.ts
+++ b/himvirasat-frontend/lib/seeded-rng.ts
@@ -1,0 +1,34 @@
+/**
+ * Deterministic pseudo-randomness for anything rendered on both the server
+ * and the client.
+ *
+ * `Math.random()` in a render path produces different markup on each side
+ * of hydration, which React reports as a mismatch and then silently
+ * repaints. Every decorative pattern and animation stagger in the design
+ * system draws from here instead, seeded by a constant, so both passes
+ * agree byte for byte.
+ */
+
+/** mulberry32 — small, fast, fully deterministic. */
+export function makeRng(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Turns a string into a stable 32-bit seed, so a component can seed itself
+ * from its own content rather than needing a magic number passed in.
+ */
+export function seedFromString(input: string) {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}

--- a/himvirasat-frontend/lib/services/admin/admin-auth-service.ts
+++ b/himvirasat-frontend/lib/services/admin/admin-auth-service.ts
@@ -2,7 +2,6 @@ import { API_URL } from "@/lib/constants";
 
 export class AdminAuthService {
   static async login(username: string, password: string) {
-    console.log(API_URL);
     const response = await fetch(`${API_URL}/auth/login`, {
       method: "POST",
       credentials: "include",

--- a/himvirasat-frontend/lib/services/admin/dashboard-service.ts
+++ b/himvirasat-frontend/lib/services/admin/dashboard-service.ts
@@ -1,6 +1,5 @@
 import { API_URL } from "@/lib/constants";
-import { DashboardStats } from "@/types/admin/user";
-import { resolve } from "node:dns";
+import { DashboardStats } from "@/types/admin/dashboard";
 
 export class DashboardService {
   static async getStats(): Promise<DashboardStats> {
@@ -8,7 +7,6 @@ export class DashboardService {
       credentials: "include",
     });
     const result = await response.json();
-    console.log(result.message);
     if (!response.ok) {
       throw new Error("Failed to fetch dashboard stats");
     }

--- a/himvirasat-frontend/lib/services/admin/user-service.ts
+++ b/himvirasat-frontend/lib/services/admin/user-service.ts
@@ -1,10 +1,9 @@
+import { API_URL } from "@/lib/constants";
 import type {
   DeleteLanguageExpertResponse,
   LanguageExpert,
   LanguageHead,
 } from "@/types/admin/user";
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
 export interface CreateLanguageExpertRequest {
   fullName: string;

--- a/himvirasat-frontend/lib/site.ts
+++ b/himvirasat-frontend/lib/site.ts
@@ -1,0 +1,16 @@
+export const site = {
+  name: "HimVirasat",
+  nativeName: "हिमविरासत",
+  takriName: "𑚩𑚮𑚢𑚦𑚮𑚤𑚭𑚨𑚙",
+  tagline: "Preserving Himachal's Linguistic Heritage",
+  description:
+    "HimVirasat is an open source initiative, driven by the community, documenting and preserving the languages and dialects of Himachal Pradesh through open translation datasets, vocabulary archives, and script tools.",
+  // TODO(maintainers): set NEXT_PUBLIC_SITE_URL to the canonical domain.
+  url: process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000",
+  links: {
+    github: "https://github.com/HimVirasat",
+    repo: "https://github.com/HimVirasat/HimVirasat-web",
+    discordHimvirasat: "https://discord.gg/PgJWcFXRTB",
+    discordHpCommunity: "https://discord.gg/wHjT3vMAVx",
+  },
+} as const;

--- a/himvirasat-frontend/lib/utils.ts
+++ b/himvirasat-frontend/lib/utils.ts
@@ -1,5 +1,36 @@
 import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+/**
+ * The design system adds named font sizes (`text-title`, `text-eyebrow`,
+ * `text-body-sm`, …). tailwind-merge cannot tell those from colour
+ * utilities, so without this it classifies `text-title` as a *colour* and
+ * silently drops the `text-muted-foreground` sitting next to it. Every
+ * custom size paired with a colour would lose the colour.
+ */
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [
+        {
+          text: [
+            "display-xl",
+            "display-lg",
+            "display-md",
+            "title",
+            "label",
+            "nav",
+            "body-lg",
+            "body",
+            "body-sm",
+            "eyebrow",
+            "eyebrow-lg",
+          ],
+        },
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/himvirasat-frontend/package.json
+++ b/himvirasat-frontend/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
-    "@icons-pack/react-simple-icons": "^13.11.2",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-table": "^8.21.3",

--- a/himvirasat-frontend/types/admin/dashboard.ts
+++ b/himvirasat-frontend/types/admin/dashboard.ts
@@ -1,0 +1,5 @@
+export interface DashboardStats {
+  languageExpertsCount: number;
+  languageHeadsCount: number;
+  superAdminsCount: number;
+}

--- a/himvirasat-frontend/types/admin/user.ts
+++ b/himvirasat-frontend/types/admin/user.ts
@@ -2,7 +2,7 @@ export interface UserDto {
   id: string;
   username: string;
   full_name: string;
-  role: "super_admin" | "language_expert";
+  role: "super_admin" | "language_head" | "language_expert";
   dialects: string[];
 }
 
@@ -28,12 +28,6 @@ export interface LanguageHead {
   is_active: boolean;
   created_at: string;
   points: number;
-}
-
-export interface DashboardStats {
-  languageExpertsCount: number;
-  languageHeadsCount: number;
-  superAdminsCount: number;
 }
 export interface DeleteLanguageExpertResponse {
   success: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,9 +113,6 @@ importers:
       '@himvirasat/shared':
         specifier: workspace:*
         version: link:../packages/shared
-      '@icons-pack/react-simple-icons':
-        specifier: ^13.11.2
-        version: 13.13.0(react@18.2.0)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.3.0(@types/react@18.3.31)(react@18.2.0)
@@ -736,12 +733,6 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
-
-  '@icons-pack/react-simple-icons@13.13.0':
-    resolution: {integrity: sha512-B5HhQMIpcSH4z8IZ8HFhD59CboHceKYMpPC9kAwGyKntvPdyJJv26DLu4Z1wAjcCLyrJhf11tMhiQGom9Rxb9g==}
-    engines: {node: '>=24', pnpm: '>=10'}
-    peerDependencies:
-      react: ^16.13 || ^17 || ^18 || ^19
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -5679,10 +5670,6 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@icons-pack/react-simple-icons@13.13.0(react@18.2.0)':
-    dependencies:
-      react: 18.2.0
-
   '@img/colour@1.1.0':
     optional: true
 
@@ -8174,8 +8161,8 @@ snapshots:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.7.0))
@@ -8202,7 +8189,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8213,18 +8200,18 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8238,7 +8225,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8249,7 +8236,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
Chaitanya saw the deployed build in Discord and asked for a PR — this is the first of three.

**Live:** https://himvirasat.vercel.app

## What this is

The public UI moves from the neo-brutalist treatment to a quiet, editorial system: structure carried by 1px rules rather than fills and elevation, colour used as decoration and never as the only carrier of meaning.

- **Token layer** in `app/globals.css` re-points the shadcn contract, so `components/ui` restyles from one place instead of file by file.
- **`components/mistral/*`** — ruled grids, pixel icons on a shared 6×6 lattice, eyebrows, arrow rows, section headings, ink bands, sticky rails.
- **The Takri mosaic** is the signature graphic: tiles carrying single Takri letters and Himachali motifs, each one a four-sided prism that turns to reveal different letters, icons and colours. Pure CSS, seeded from a fixed PRNG so server and client markup match, and paused when off-screen so the page actually goes idle.
- **Navbar** with a three-panel mega-menu, and a rebuilt footer.
- **Every public page rebuilt** — home, about, vocabulary, datasets, contribute, tools, transliterator.
- **Favicon fixed.** `app/favicon.ico` was overriding the generated `app/icon.tsx` at 32px, so tabs showed the old mark. Deleted; `apple-icon.tsx` added.

## Calls worth arguing about

I would rather flag these than have you find them in the diff.

- **The accent palette changes.** Emerald is replaced by a Deodar ramp — pine greens, glacial blue-greens, kath-kuni clay browns. Biggest aesthetic decision here and the one most worth pushing back on.
- **Geist** becomes the display face, self-hosted through `next/font/google` — no new dependency, no external request.
- **`@icons-pack/react-simple-icons` is removed.** It arrived recently for a single GitHub glyph. The GitHub link stays, as a text link in the nav's hairline-cell idiom, which also reads better in an editorial nav than an icon button.
- **Six files deleted**, including `components/layout/background-decor.tsx` and `components/decor/`, superseded by the ruled-grid mechanic.
- **A stray `import { resolve } from "node:dns"`** removed from `dashboard-service.ts` — it is a frontend module and that import would not survive a browser bundle.

## Open questions for you

Two `TODO(copy)` comments in `app/(public)/page.tsx`. I wrote the honest, checkable version of each claim, but the framing of the four "why contribute" points and the featured items are yours to confirm or rewrite.

## Scope

The **admin dashboard** is untouched here and lands in a separate PR. The **scroll-driven motion** the live site has — the scrubbed hero, section entrances, rail progress — also lands separately, since it adds a dependency and deserves its own decision. The hero markup here already carries the hooks that change needs, so it is additive rather than a rewrite.

I know CONTRIBUTING asks for an issue before a large change; opening directly since the PR was requested in Discord. Happy to file one retroactively if you would rather track it that way.

## Verification

`pnpm -r typecheck`, frontend lint and a 24-route build all clean from the repo root. Contrast checked across both themes at 390 and 1440 with no failures, no horizontal overflow, console clean.